### PR TITLE
fix: return date in matches as ISO string

### DIFF
--- a/app/backend/src/schema/common.schema.js
+++ b/app/backend/src/schema/common.schema.js
@@ -42,7 +42,7 @@ const commonDefinitionsSchema = {
     },
     date: {
       type: "string",
-      format: "date",
+      format: "date-time",
       description: "A date in ISO 8601 format."
     }
   }


### PR DESCRIPTION
The date of each match is stored as a DateTime object containing the date and the time of creation of the match in the db. When fetching this information the Match type expects a string for the date. To fullfill the request Fastify implicitly converts the DateTime object into a string. The issue was that along that stringification the time information got lost and only the date itself got returned to the frontend. Therefore when being called the .toLocaleString() method defaulted to the value 2:00:00 AM for a lack of actual information.

To fix this, each service that returns a match/multiple matches explicitly converts the DateTime object into a ISOString in order to preserve the time information. 

closes #52 