### PR TITLE
90 failed refreshaccesstoken can lead to incorrect page view

### DIFF
--- a/app/frontend/src/main.ts
+++ b/app/frontend/src/main.ts
@@ -37,7 +37,7 @@ document.addEventListener("DOMContentLoaded", () => {
     auth.onChange(async (isAuth) => {
       const path = window.location.pathname;
       if (!isAuth && path !== "/login") {
-        alert("User was logged out");
+        console.log("Redirecting to login");
         await router.navigate("/login", false);
       }
     });

--- a/app/frontend/src/routing/Router.ts
+++ b/app/frontend/src/routing/Router.ts
@@ -8,6 +8,9 @@ import {
 import ErrorView from "../views/ErrorView.js";
 import { Layout } from "../Layout.js";
 import { stopOnlineStatusTracking } from "../services/onlineStatusServices.js";
+import { ApiError } from "../services/api.js";
+import { auth } from "../AuthManager.js";
+import { toaster } from "../Toaster.js";
 
 export class Router {
   private static instance: Router;
@@ -98,6 +101,12 @@ export class Router {
 
   async handleError(message: string, error: unknown) {
     console.error(message, error);
+    if (error instanceof ApiError && error.status === 401) {
+      console.error("Could not verify user");
+      toaster.error("Could not verify user, sending to Login page");
+      auth.clearTokenOnError();
+      return;
+    }
     const view = new ErrorView(error);
     await this.setView(view);
   }

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -1,4 +1,3 @@
-import { auth } from "../AuthManager.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 import { refreshAccessToken } from "./authServices.js";
 
@@ -33,14 +32,8 @@ export async function apiFetch<T>(
 
     if (!response.ok) {
       if (response.status === 401 && retryWithRefresh) {
-        try {
-          await refreshAccessToken();
-          return apiFetch<T>(url, options, false);
-        } catch (refreshError) {
-          console.error(refreshError);
-          auth.clearTokenOnError();
-          return json as ApiResponse<T>;
-        }
+        await refreshAccessToken();
+        return apiFetch<T>(url, options, false);
       }
       throw new ApiError(response.status, json.message, json.cause);
     }


### PR DESCRIPTION
Fixes bug as described in #90 

- refreshAccessToken() throws normally, is not catched within apiFetch
- in router.handleError() we check if 401. If so we don't switchView to errorView. We remove auth State to trigger redirect
- also removed alert and used console.log and toast instead