### PR TITLE
97 remove userid from match model

### DIFF
--- a/app/backend/prisma/migrations/20250630064948_add_none_to_played_as/migration.sql
+++ b/app/backend/prisma/migrations/20250630064948_add_none_to_played_as/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - Made the column `userId` on table `matches` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_matches" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "userId" INTEGER NOT NULL,
+    "playedAs" TEXT NOT NULL DEFAULT 'PLAYERONE',
+    "player1Nickname" TEXT NOT NULL,
+    "player2Nickname" TEXT NOT NULL,
+    "player1Score" INTEGER NOT NULL,
+    "player2Score" INTEGER NOT NULL,
+    "tournamentId" INTEGER,
+    "date" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "matches_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "matches_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "tournaments" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_matches" ("date", "id", "playedAs", "player1Nickname", "player1Score", "player2Nickname", "player2Score", "tournamentId", "userId") SELECT "date", "id", coalesce("playedAs", 'PLAYERONE') AS "playedAs", "player1Nickname", "player1Score", "player2Nickname", "player2Score", "tournamentId", "userId" FROM "matches";
+DROP TABLE "matches";
+ALTER TABLE "new_matches" RENAME TO "matches";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -84,8 +84,8 @@ model FriendRequest {
 
 model Match {
     id               Int        @id @default(autoincrement())
-    userId           Int?
-    playedAs         PlayedAs?
+    userId           Int
+    playedAs         PlayedAs   @default(PLAYERONE)
     player1Nickname  String
     player2Nickname  String
     player1Score     Int
@@ -93,7 +93,7 @@ model Match {
     tournamentId     Int?
     date             DateTime   @default(now())
 
-    user       User?        @relation("UserPlayed", fields: [userId], references: [id], onDelete: Cascade)
+    user       User        @relation("UserPlayed", fields: [userId], references: [id], onDelete: Cascade)
     tournament Tournament?  @relation(fields: [tournamentId], references: [id])
 
     @@map("matches")
@@ -116,6 +116,7 @@ model Tournament {
 }
 
 enum PlayedAs {
+    NONE
     PLAYERONE
     PLAYERTWO
 }

--- a/app/backend/src/controllers/matches.controllers.js
+++ b/app/backend/src/controllers/matches.controllers.js
@@ -11,8 +11,8 @@ import { handlePrismaError } from "../utils/error.js";
 export async function createMatchHandler(request, reply) {
   const action = "Create match";
   try {
+    const userId = parseInt(request.user.id, 10);
     const {
-      userId,
       playedAs,
       player1Nickname,
       player2Nickname,
@@ -32,7 +32,7 @@ export async function createMatchHandler(request, reply) {
     );
 
     let stats = null;
-    if (userId !== null) {
+    if (playedAs !== "NONE") {
       const isPlayerOne = playedAs === "PLAYERONE";
       stats = await updateUserStats(
         userId,

--- a/app/backend/src/controllers/users.controllers.js
+++ b/app/backend/src/controllers/users.controllers.js
@@ -140,7 +140,8 @@ export async function getUserMatchesHandler(request, reply) {
   const action = "Get user matches";
   try {
     const id = parseInt(request.user.id, 10);
-    const data = await getUserMatches(id);
+    const { playedAs } = request.query;
+    const data = await getUserMatches(id, playedAs);
     const count = data.length;
     return reply.code(200).send({
       message: createResponseMessage(action, true),

--- a/app/backend/src/routes/users.routes.js
+++ b/app/backend/src/routes/users.routes.js
@@ -153,6 +153,7 @@ const optionsDeleteUser = {
 const optionsGetUserMatches = {
   onRequest: [authorizeUserAccess],
   schema: {
+    querystring: { $ref: "querystringMatchSchema" },
     response: {
       200: { $ref: "matchArrayResponseSchema" },
       ...errorResponses

--- a/app/backend/src/schema/matches.schema.js
+++ b/app/backend/src/schema/matches.schema.js
@@ -141,11 +141,25 @@ export const createMatchResponseSchema = {
   additionalProperties: false
 };
 
+export const querystringMatchSchema = {
+  $id: "querystringMatchSchema",
+  type: "object",
+  properties: {
+    playedAs: {
+      type: "array",
+      items: { $ref: "matchDefinitionsSchema#/definitions/playedAs" },
+      description: "Filter roles (array of values)"
+    }
+  },
+  additionalProperties: false
+};
+
 export const matchSchemas = [
   matchDefinitionsSchema,
   matchSchema,
   matchResponseSchema,
   matchArrayResponseSchema,
   createMatchSchema,
-  createMatchResponseSchema
+  createMatchResponseSchema,
+  querystringMatchSchema
 ];

--- a/app/backend/src/schema/matches.schema.js
+++ b/app/backend/src/schema/matches.schema.js
@@ -13,10 +13,6 @@ const matchSchema = {
   $id: "matchSchema",
   type: "object",
   properties: {
-    userId: {
-      $ref: "commonDefinitionsSchema#/definitions/id",
-      description: "The unique identifier for the logged-in user"
-    },
     playedAs: { $ref: "matchDefinitionsSchema#/definitions/playedAs" },
     player1Nickname: {
       $ref: "commonDefinitionsSchema#/definitions/username",
@@ -54,7 +50,6 @@ const matchSchema = {
     }
   },
   required: [
-    "userId",
     "playedAs",
     "player1Nickname",
     "player2Nickname",

--- a/app/backend/src/schema/matches.schema.js
+++ b/app/backend/src/schema/matches.schema.js
@@ -1,21 +1,23 @@
+const matchDefinitionsSchema = {
+  $id: "matchDefinitionsSchema",
+  definitions: {
+    playedAs: {
+      type: "string",
+      enum: ["NONE", "PLAYERONE", "PLAYERTWO"],
+      description: "The player assignment for the logged-in user"
+    }
+  }
+};
+
 const matchSchema = {
   $id: "matchSchema",
   type: "object",
   properties: {
     userId: {
-      oneOf: [
-        { $ref: "commonDefinitionsSchema#/definitions/id" },
-        { type: "null" }
-      ],
-      description: "The optional unique identifier for the logged-in user"
+      $ref: "commonDefinitionsSchema#/definitions/id",
+      description: "The unique identifier for the logged-in user"
     },
-    playedAs: {
-      oneOf: [
-        { type: "string", enum: ["PLAYERONE", "PLAYERTWO"] },
-        { type: "null" }
-      ],
-      description: "The optional player assignment for the logged-in user"
-    },
+    playedAs: { $ref: "matchDefinitionsSchema#/definitions/playedAs" },
     player1Nickname: {
       $ref: "commonDefinitionsSchema#/definitions/username",
       description: "The nickname of player 1"
@@ -93,20 +95,7 @@ export const createMatchSchema = {
   $id: "createMatchSchema",
   type: "object",
   properties: {
-    userId: {
-      oneOf: [
-        { $ref: "commonDefinitionsSchema#/definitions/id" },
-        { type: "null" }
-      ],
-      description: "The optional unique identifier for the logged-in user"
-    },
-    playedAs: {
-      oneOf: [
-        { type: "string", enum: ["PLAYERONE", "PLAYERTWO"] },
-        { type: "null" }
-      ],
-      description: "The optional player assignment for the logged-in user"
-    },
+    playedAs: { $ref: "matchDefinitionsSchema#/definitions/playedAs" },
     player1Nickname: {
       $ref: "commonDefinitionsSchema#/definitions/username",
       description: "The nickname of player 1"
@@ -124,21 +113,12 @@ export const createMatchSchema = {
       description: "The score of player 2 in the match"
     },
     tournament: {
-      oneOf: [
-        {
-          type: "object",
-          properties: {
-            id: { $ref: "commonDefinitionsSchema#/definitions/id" },
-            name: { type: "string" }
-          },
-          required: ["id", "name"]
-        },
-        { type: "null" }
-      ],
-      description: "The tournament details if this match belongs to one"
+      oneOf: [{ $ref: "idSchema" }, { type: "null" }],
+      description: "The tournament id if this match belongs to one"
     }
   },
   required: [
+    "playedAs",
     "player1Nickname",
     "player2Nickname",
     "player1Score",
@@ -167,6 +147,7 @@ export const createMatchResponseSchema = {
 };
 
 export const matchSchemas = [
+  matchDefinitionsSchema,
   matchSchema,
   matchResponseSchema,
   matchArrayResponseSchema,

--- a/app/backend/src/services/matches.services.js
+++ b/app/backend/src/services/matches.services.js
@@ -67,10 +67,11 @@ export async function getMatch(id) {
   return match;
 }
 
-export async function getUserMatches(userId) {
+export async function getUserMatches(userId, playedAs) {
   const matches = await prisma.match.findMany({
     where: {
-      userId: userId
+      userId: userId,
+      ...(playedAs ? { playedAs: { in: playedAs } } : {})
     },
     select: matchSelect
   });

--- a/app/backend/src/services/matches.services.js
+++ b/app/backend/src/services/matches.services.js
@@ -1,7 +1,6 @@
 import prisma from "../prisma/prismaClient.js";
 
 const matchSelect = {
-  userId: true,
   playedAs: true,
   player1Nickname: true,
   player2Nickname: true,

--- a/app/frontend/src/components/MatchRow.ts
+++ b/app/frontend/src/components/MatchRow.ts
@@ -1,8 +1,8 @@
-import { Match } from "../types/IMatch.js";
+import { Match, playedAs } from "../types/IMatch.js";
 import { escapeHTML } from "../utility.js";
 
 export function MatchRow(match: Match, user: string): string {
-  const isPlayerOne = match.playedAs === "PLAYERONE";
+  const isPlayerOne = match.playedAs === playedAs.PLAYERONE;
 
   const result = isPlayerOne
     ? match.player1Score > match.player2Score

--- a/app/frontend/src/game.ts
+++ b/app/frontend/src/game.ts
@@ -5,8 +5,8 @@ import { GameKey } from "./views/GameView.js";
 import { Tournament } from "./Tournament.js";
 import { updateTournamentBracket } from "./services/tournamentService.js";
 import { createMatch } from "./services/matchServices.js";
-import { auth } from "./AuthManager.js";
 import { GameType } from "./views/GameView.js";
+import { playedAs } from "./types/IMatch.js";
 
 let isAborted: boolean = false;
 
@@ -21,7 +21,7 @@ export function setIsAborted(value: boolean) {
 export async function startGame(
   nickname1: string,
   nickname2: string,
-  userRole: string | null,
+  userRole: playedAs,
   gameType: GameType,
   tournament: Tournament | null,
   keys: Record<GameKey, boolean>
@@ -138,7 +138,7 @@ function checkWinner(gameState: GameState) {
 async function endGame(
   gameState: GameState,
   tournament: Tournament | null,
-  userRole: string | null
+  userRole: playedAs
 ) {
   if (tournament) {
     const matchId = tournament.getNextMatchToPlay()!.matchId;
@@ -151,15 +151,14 @@ async function endGame(
   }
 
   await createMatch({
-    tournament: tournament
-      ? { id: tournament!.getId(), name: tournament!.getTournamentName() }
-      : null,
-    userId: userRole ? auth.getToken().id : null,
     playedAs: userRole,
     player1Nickname: gameState.player1,
     player2Nickname: gameState.player2,
     player1Score: gameState.player1Score,
-    player2Score: gameState.player2Score
+    player2Score: gameState.player2Score,
+    tournament: tournament
+      ? { id: tournament!.getId(), name: tournament!.getTournamentName() }
+      : null
   });
 
   await waitForEnterKey();

--- a/app/frontend/src/services/userServices.ts
+++ b/app/frontend/src/services/userServices.ts
@@ -2,11 +2,14 @@ import { apiFetch } from "./api.js";
 import { Match } from "../types/IMatch.js";
 import { User } from "../types/User.js";
 
-export async function getUserMatches(): Promise<Match[]> {
-  const apiResponse = await apiFetch<Match[]>("/api/users/me/matches", {
-    method: "GET",
-    credentials: "same-origin"
-  });
+export async function getUserPlayedMatches(): Promise<Match[]> {
+  const apiResponse = await apiFetch<Match[]>(
+    "/api/users/me/matches?playedAs=PLAYERONE&playedAs=PLAYERTWO",
+    {
+      method: "GET",
+      credentials: "same-origin"
+    }
+  );
 
   console.log(apiResponse);
   return apiResponse.data;

--- a/app/frontend/src/types/IMatch.ts
+++ b/app/frontend/src/types/IMatch.ts
@@ -1,14 +1,20 @@
+export enum playedAs {
+  NONE,
+  PLAYERONE,
+  PLAYERTWO
+}
+
 export interface Match {
-  tournament?: {
-    id: number;
-    name: string;
-  } | null;
-  userId?: number | null;
-  playedAs?: string | null;
+  userId?: number;
+  playedAs: playedAs;
   player1Nickname: string;
   player2Nickname: string;
   player1Score: number;
   player2Score: number;
+  tournament?: {
+    id: number;
+    name: string;
+  } | null;
   date?: string;
 }
 

--- a/app/frontend/src/types/IMatch.ts
+++ b/app/frontend/src/types/IMatch.ts
@@ -1,7 +1,7 @@
 export enum playedAs {
-  NONE,
-  PLAYERONE,
-  PLAYERTWO
+  NONE = "NONE",
+  PLAYERONE = "PLAYERONE",
+  PLAYERTWO = "PLAYERTWO"
 }
 
 export interface Match {

--- a/app/frontend/src/types/IMatch.ts
+++ b/app/frontend/src/types/IMatch.ts
@@ -5,7 +5,6 @@ export enum playedAs {
 }
 
 export interface Match {
-  userId?: number;
   playedAs: playedAs;
   player1Nickname: string;
   player2Nickname: string;

--- a/app/frontend/src/views/GameView.ts
+++ b/app/frontend/src/views/GameView.ts
@@ -5,6 +5,7 @@ import MatchAnnouncement from "./MatchAnnouncementView.js";
 import ResultsView from "./ResultsView.js";
 import NewGameView from "./NewGameView.js";
 import { Tournament } from "../Tournament.js";
+import { playedAs } from "../types/IMatch.js";
 
 export type GameKey = "w" | "s" | "ArrowUp" | "ArrowDown";
 
@@ -25,7 +26,7 @@ export class GameView extends AbstractView {
   constructor(
     private nickname1: string,
     private nickname2: string,
-    private userRole: string | null,
+    private userRole: playedAs,
     private gameType: GameType,
     private tournament: Tournament | null
   ) {

--- a/app/frontend/src/views/MatchAnnouncementView.ts
+++ b/app/frontend/src/views/MatchAnnouncementView.ts
@@ -8,13 +8,14 @@ import { Header1 } from "../components/Header1.js";
 import { Paragraph } from "../components/Paragraph.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
+import { playedAs } from "../types/IMatch.js";
 
 export default class MatchAnnouncementView extends AbstractView {
   private player1: string;
   private player2: string;
   private matchNumber: number;
   private roundNumber: number;
-  private userRole: "PLAYERONE" | "PLAYERTWO" | null = null;
+  private userRole: playedAs;
 
   constructor(private tournament: Tournament) {
     super();
@@ -30,10 +31,10 @@ export default class MatchAnnouncementView extends AbstractView {
     const userNickname = tournament.getUserNickname();
     this.userRole =
       this.player1 === userNickname
-        ? "PLAYERONE"
+        ? playedAs.PLAYERONE
         : this.player2 === userNickname
-          ? "PLAYERTWO"
-          : null;
+          ? playedAs.PLAYERTWO
+          : playedAs.NONE;
   }
 
   createHTML() {

--- a/app/frontend/src/views/NewGameView.ts
+++ b/app/frontend/src/views/NewGameView.ts
@@ -8,6 +8,7 @@ import { Paragraph } from "../components/Paragraph.js";
 import { escapeHTML } from "../utility.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
+import { playedAs } from "../types/IMatch.js";
 
 export default class NewGameView extends AbstractView {
   private formEl!: HTMLFormElement;
@@ -67,7 +68,7 @@ export default class NewGameView extends AbstractView {
     const gameView = new GameView(
       nicknames[0],
       nicknames[1],
-      userNumber == "1" ? "PLAYERONE" : "PLAYERTWO",
+      userNumber == "1" ? playedAs.PLAYERONE : playedAs.PLAYERTWO,
       GameType.single,
       null
     );

--- a/app/frontend/src/views/StatsView.ts
+++ b/app/frontend/src/views/StatsView.ts
@@ -1,6 +1,6 @@
 import AbstractView from "./AbstractView.js";
 import { getUserStats } from "../services/userStatsServices.js";
-import { getUserMatches } from "../services/userServices.js";
+import { getUserPlayedMatches } from "../services/userServices.js";
 import { escapeHTML } from "../utility.js";
 import { auth } from "../AuthManager.js";
 import { Header1 } from "../components/Header1.js";
@@ -89,7 +89,7 @@ export default class StatsView extends AbstractView {
 
   async getMatchesHTML(): Promise<string> {
     const user = escapeHTML(auth.getToken().username);
-    const matchesRaw = await getUserMatches();
+    const matchesRaw = await getUserPlayedMatches();
 
     if (matchesRaw.length === 0) {
       return `<tr><td colspan="7" class="text-center text-teal py-4">No matches played yet</td></tr>`;


### PR DESCRIPTION
Problem: 
- match was saved with userId as optional param
- If userId is provided another optional param can be set: playedAs (PLAYERONE or PLAYERTWO)
- usage was for tournament: if user is none of the players is paricipating in the match, we didn't save userId
- match then has indirect connection to user over tournament
- but we also don't delete matches if a tournament is aborted: intention was user should not be able to abort unfavorable tournament to push his stats
- a match with no userId and aborted tournament would be in DB with no connection to user

Fix:
- update match model to require userId and playedAs
- playedAs enum gets new value: "NONE"
- matches can now be filtered by playedAs to only get matches played (like before)
- introduce playedAs enum in frontend to make string values explicit
- we never use userId returned by match: deleted from schemas and not returned