### PR TITLE
117 rewrite apifetch to include error code

### DIFF
--- a/app/frontend/src/AuthManager.ts
+++ b/app/frontend/src/AuthManager.ts
@@ -77,7 +77,7 @@ export class AuthManager {
       this.user = unwrap(await getUserProfile());
       this.updateAuthState(token);
     } catch (error) {
-      router.handleError("Error while initialize:", error);
+      router.handleError("Error in AuthManager.initialize():", error);
     }
   }
 

--- a/app/frontend/src/AuthManager.ts
+++ b/app/frontend/src/AuthManager.ts
@@ -113,7 +113,9 @@ export class AuthManager {
       if (!apiResponse.success) {
         if (apiResponse.status === 401) {
           console.warn("No auth cookies set");
-        } else throw new ApiError(apiResponse);
+        } else {
+          throw new ApiError(apiResponse);
+        }
       }
 
       const sidebar = document.getElementById("drawer-sidebar");

--- a/app/frontend/src/AuthManager.ts
+++ b/app/frontend/src/AuthManager.ts
@@ -108,7 +108,10 @@ export class AuthManager {
   }
 
   public async logout(): Promise<void> {
-    await userLogout();
+    const apiResponse = await userLogout();
+    if (!apiResponse.success) {
+      console.error("Error while logout()", apiResponse.message);
+    }
 
     const sidebar = document.getElementById("drawer-sidebar");
     if (sidebar) sidebar.remove();

--- a/app/frontend/src/AuthManager.ts
+++ b/app/frontend/src/AuthManager.ts
@@ -108,15 +108,22 @@ export class AuthManager {
   }
 
   public async logout(): Promise<void> {
-    const apiResponse = await userLogout();
-    if (!apiResponse.success) {
-      console.error("Error while logout()", apiResponse.message);
+    try {
+      const apiResponse = await userLogout();
+      if (!apiResponse.success) {
+        if (apiResponse.status === 401) {
+          console.warn("No auth cookies set");
+        } else throw new ApiError(apiResponse);
+      }
+
+      const sidebar = document.getElementById("drawer-sidebar");
+      if (sidebar) sidebar.remove();
+
+      this.updateAuthState(null);
+    } catch (error) {
+      console.error("Error while logout()", error);
+      toaster.error("Error while logging out. Try again later.");
     }
-
-    const sidebar = document.getElementById("drawer-sidebar");
-    if (sidebar) sidebar.remove();
-
-    this.updateAuthState(null);
   }
 
   public clearTokenOnError(): void {

--- a/app/frontend/src/AuthManager.ts
+++ b/app/frontend/src/AuthManager.ts
@@ -1,5 +1,5 @@
 import { router } from "./routing/Router.js";
-import { ApiError, unwrap } from "./services/api.js";
+import { ApiError, getDataOrThrow } from "./services/api.js";
 import {
   authAndDecodeAccessToken,
   refreshAccessToken,
@@ -74,7 +74,7 @@ export class AuthManager {
         }
       }
       const token = apiResponse.data;
-      this.user = unwrap(await getUserProfile());
+      this.user = getDataOrThrow(await getUserProfile());
       this.updateAuthState(token);
     } catch (error) {
       router.handleError("Error in AuthManager.initialize():", error);
@@ -92,8 +92,8 @@ export class AuthManager {
           throw new ApiError(apiResponse);
         }
       }
-      const token = unwrap(await authAndDecodeAccessToken());
-      this.user = unwrap(await getUserProfile());
+      const token = getDataOrThrow(await authAndDecodeAccessToken());
+      this.user = getDataOrThrow(await getUserProfile());
       console.log("User logged in");
       this.updateAuthState(token);
       return true;
@@ -232,7 +232,7 @@ export class AuthManager {
           throw new ApiError(apiResponse);
         }
       }
-      const newToken = unwrap(await authAndDecodeAccessToken());
+      const newToken = getDataOrThrow(await authAndDecodeAccessToken());
       this.updateAuthState(newToken);
     } catch (error) {
       console.warn("Token refresh failed", error);

--- a/app/frontend/src/AuthManager.ts
+++ b/app/frontend/src/AuthManager.ts
@@ -117,7 +117,11 @@ export class AuthManager {
   }
 
   public clearTokenOnError(): void {
-    this.updateAuthState(null);
+    if (this.authenticated) {
+      console.error("Could not verify user");
+      toaster.error("Could not verify user:<br>Sending to Login page");
+      this.updateAuthState(null);
+    }
   }
 
   public isAuthenticated(): boolean {

--- a/app/frontend/src/game.ts
+++ b/app/frontend/src/game.ts
@@ -7,6 +7,7 @@ import { updateTournamentBracket } from "./services/tournamentService.js";
 import { createMatch } from "./services/matchServices.js";
 import { GameType } from "./views/GameView.js";
 import { playedAs } from "./types/IMatch.js";
+import { unwrap } from "./services/api.js";
 
 let isAborted: boolean = false;
 
@@ -147,19 +148,21 @@ async function endGame(
         ? gameState.player1
         : gameState.player2;
     tournament.updateBracketWithResult(matchId, winner);
-    await updateTournamentBracket(tournament);
+    unwrap(await updateTournamentBracket(tournament));
   }
 
-  await createMatch({
-    playedAs: userRole,
-    player1Nickname: gameState.player1,
-    player2Nickname: gameState.player2,
-    player1Score: gameState.player1Score,
-    player2Score: gameState.player2Score,
-    tournament: tournament
-      ? { id: tournament!.getId(), name: tournament!.getTournamentName() }
-      : null
-  });
+  unwrap(
+    await createMatch({
+      playedAs: userRole,
+      player1Nickname: gameState.player1,
+      player2Nickname: gameState.player2,
+      player1Score: gameState.player1Score,
+      player2Score: gameState.player2Score,
+      tournament: tournament
+        ? { id: tournament!.getId(), name: tournament!.getTournamentName() }
+        : null
+    })
+  );
 
   await waitForEnterKey();
 }

--- a/app/frontend/src/game.ts
+++ b/app/frontend/src/game.ts
@@ -7,7 +7,7 @@ import { updateTournamentBracket } from "./services/tournamentService.js";
 import { createMatch } from "./services/matchServices.js";
 import { GameType } from "./views/GameView.js";
 import { playedAs } from "./types/IMatch.js";
-import { unwrap } from "./services/api.js";
+import { getDataOrThrow } from "./services/api.js";
 
 let isAborted: boolean = false;
 
@@ -148,10 +148,10 @@ async function endGame(
         ? gameState.player1
         : gameState.player2;
     tournament.updateBracketWithResult(matchId, winner);
-    unwrap(await updateTournamentBracket(tournament));
+    getDataOrThrow(await updateTournamentBracket(tournament));
   }
 
-  unwrap(
+  getDataOrThrow(
     await createMatch({
       playedAs: userRole,
       player1Nickname: gameState.player1,

--- a/app/frontend/src/routing/Router.ts
+++ b/app/frontend/src/routing/Router.ts
@@ -10,8 +10,6 @@ import {
 import ErrorView from "../views/ErrorView.js";
 import { closeSSEConnection } from "../services/serverSentEventsServices.js";
 import { ApiError } from "../services/api.js";
-import { auth } from "../AuthManager.js";
-import { toaster } from "../Toaster.js";
 
 export class Router {
   private static instance: Router;

--- a/app/frontend/src/routing/Router.ts
+++ b/app/frontend/src/routing/Router.ts
@@ -134,13 +134,10 @@ export class Router {
   }
 
   async handleError(message: string, error: unknown) {
-    console.error(message, error);
     if (error instanceof ApiError && error.status === 401) {
-      console.error("Could not verify user");
-      toaster.error("Could not verify user:<br>Sending to Login page");
-      auth.clearTokenOnError();
       return;
     }
+    console.error(message, error);
     const view = new ErrorView(error);
     await this.setView(view);
   }

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -22,10 +22,12 @@ export class ApiError extends Error {
 }
 
 function success<T>(message: string, data: T): ApiSuccess<T> {
+  console.log({message, data});
   return { success: true, message, data };
 }
 
 function error(message: string, status: number, cause?: string): ApiFail {
+  console.error({message, status, cause});
   return { success: false, message, status, cause };
 }
 

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -13,7 +13,7 @@ export class ApiError extends Error {
   }
 }
 
-function success<T>(data: T, message: string): ApiSuccess<T> {
+function success<T>(message: string, data: T): ApiSuccess<T> {
   return { success: true, message, data };
 }
 

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -22,7 +22,7 @@ export class ApiError extends Error {
   }
 }
 
-export function unwrap<T>(response: ApiResponse<T>): T {
+export function getDataOrThrow<T>(response: ApiResponse<T>): T {
   if (response.success) {
     return response.data;
   } else {
@@ -55,15 +55,15 @@ export async function apiFetch<T>(
         }
         return retryResponse;
       }
-      return setError(json.message, response.status, json.cause);
+      return createApiFail(json.message, response.status, json.cause);
     }
 
-    return setSuccess(json.message, json.data);
+    return createApiSuccess(json.message, json.data);
   } catch (error) {
     if (error instanceof Error) {
-      return setError("Internal server error", 500, error.message ?? undefined);
+      return createApiFail("Internal server error", 500, error.message ?? undefined);
     } else {
-      return setError("Internal server error", 500);
+      return createApiFail("Internal server error", 500);
     }
   }
 }
@@ -92,12 +92,12 @@ async function refreshAndRetry<T>(
   return apiFetch<T>(url, options, false);
 }
 
-function setSuccess<T>(message: string, data: T): ApiSuccess<T> {
+function createApiSuccess<T>(message: string, data: T): ApiSuccess<T> {
   console.log({ message, data });
   return { success: true, message, data };
 }
 
-function setError(message: string, status: number, cause?: string): ApiFail {
+function createApiFail(message: string, status: number, cause?: string): ApiFail {
   console.error({ message, status, cause });
   return { success: false, message, status, cause };
 }

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -60,9 +60,7 @@ export async function apiFetch<T>(
 
     return success(json.message, json.data);
   } catch (error) {
-    if (error instanceof ApiError) {
-      throw error;
-    }
+    console.error("Unknown error:", error);
     throw new ApiError("Internal server error", 500);
   }
 }

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -55,10 +55,10 @@ export async function apiFetch<T>(
         }
         return retryResponse;
       }
-      return error(json.message, response.status, json.cause);
+      return setError(json.message, response.status, json.cause);
     }
 
-    return success(json.message, json.data);
+    return setSuccess(json.message, json.data);
   } catch (error) {
     console.error("Unknown error:", error);
     throw new ApiError("Internal server error", 500);
@@ -89,12 +89,12 @@ async function refreshAndRetry<T>(
   return apiFetch<T>(url, options, false);
 }
 
-function success<T>(message: string, data: T): ApiSuccess<T> {
+function setSuccess<T>(message: string, data: T): ApiSuccess<T> {
   console.log({ message, data });
   return { success: true, message, data };
 }
 
-function error(message: string, status: number, cause?: string): ApiFail {
+function setError(message: string, status: number, cause?: string): ApiFail {
   console.error({ message, status, cause });
   return { success: false, message, status, cause };
 }

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -59,6 +59,6 @@ export function extractData<T>(response: ApiResponse<T>): T {
   if (response.success) {
     return response.data;
   } else {
-    throw new ApiError(response.status, response.message, response.error.code);
+    throw new ApiError(response.status, response.message, response.cause);
   }
 }

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -55,7 +55,7 @@ export async function apiFetch<T>(
   }
 }
 
-export function extractData<T>(response: ApiResponse<T>): T {
+export function unwrap<T>(response: ApiResponse<T>): T {
   if (response.success) {
     return response.data;
   } else {

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -60,8 +60,11 @@ export async function apiFetch<T>(
 
     return setSuccess(json.message, json.data);
   } catch (error) {
-    console.error("Unknown error:", error);
-    throw new ApiError("Internal server error", 500);
+    if (error instanceof Error) {
+      return setError("Internal server error", 500, error.message ?? undefined);
+    } else {
+      return setError("Internal server error", 500);
+    }
   }
 }
 

--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -22,14 +22,12 @@ export class ApiError extends Error {
   }
 }
 
-function success<T>(message: string, data: T): ApiSuccess<T> {
-  console.log({ message, data });
-  return { success: true, message, data };
-}
-
-function error(message: string, status: number, cause?: string): ApiFail {
-  console.error({ message, status, cause });
-  return { success: false, message, status, cause };
+export function unwrap<T>(response: ApiResponse<T>): T {
+  if (response.success) {
+    return response.data;
+  } else {
+    throw new ApiError(response);
+  }
 }
 
 export async function apiFetch<T>(
@@ -69,14 +67,6 @@ export async function apiFetch<T>(
   }
 }
 
-export function unwrap<T>(response: ApiResponse<T>): T {
-  if (response.success) {
-    return response.data;
-  } else {
-    throw new ApiError(response);
-  }
-}
-
 function handleRefreshFailure(response: ApiFail) {
   if (response.status === 401) {
     auth.clearTokenOnError();
@@ -99,4 +89,14 @@ async function refreshAndRetry<T>(
   }
 
   return apiFetch<T>(url, options, false);
+}
+
+function success<T>(message: string, data: T): ApiSuccess<T> {
+  console.log({ message, data });
+  return { success: true, message, data };
+}
+
+function error(message: string, status: number, cause?: string): ApiFail {
+  console.error({ message, status, cause });
+  return { success: false, message, status, cause };
 }

--- a/app/frontend/src/services/authServices.ts
+++ b/app/frontend/src/services/authServices.ts
@@ -24,11 +24,15 @@ export async function userLogin(
   usernameOrEmail: string,
   password: string
 ): Promise<ApiResponse<{ username: string }>> {
-  return apiFetch<{ username: string }>("/api/auth/login", {
-    method: "POST",
-    credentials: "same-origin",
-    body: JSON.stringify({ usernameOrEmail, password })
-  });
+  return apiFetch<{ username: string }>(
+    "/api/auth/login",
+    {
+      method: "POST",
+      credentials: "same-origin",
+      body: JSON.stringify({ usernameOrEmail, password })
+    },
+    false
+  );
 }
 
 export async function userLogout(): Promise<ApiResponse<{ username: string }>> {

--- a/app/frontend/src/services/authServices.ts
+++ b/app/frontend/src/services/authServices.ts
@@ -3,17 +3,14 @@ import { Token } from "../types/Token.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 
 export async function authAndDecodeAccessToken(): Promise<ApiResponse<Token>> {
-  const apiResponse = await apiFetch<Token>("/api/auth/token", {
+  return apiFetch<Token>("/api/auth/token", {
     method: "GET",
     credentials: "same-origin"
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
-export async function refreshAccessToken() {
-  const apiResponse = await apiFetch<null>(
+export async function refreshAccessToken(): Promise<ApiResponse<null>> {
+  return apiFetch<null>(
     "/api/auth/refresh",
     {
       method: "GET",
@@ -21,27 +18,21 @@ export async function refreshAccessToken() {
     },
     false
   );
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function userLogin(
   usernameOrEmail: string,
   password: string
 ): Promise<ApiResponse<{ username: string }>> {
-  const apiResponse = await apiFetch<{ username: string }>("/api/auth/login", {
+  return apiFetch<{ username: string }>("/api/auth/login", {
     method: "POST",
     credentials: "same-origin",
     body: JSON.stringify({ usernameOrEmail, password })
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function userLogout(): Promise<ApiResponse<{ username: string }>> {
-  const apiResponse = await apiFetch<{ username: string }>(
+  return apiFetch<{ username: string }>(
     "/api/auth/logout",
     {
       method: "PATCH",
@@ -49,7 +40,4 @@ export async function userLogout(): Promise<ApiResponse<{ username: string }>> {
     },
     false
   );
-
-  console.log(apiResponse);
-  return apiResponse;
 }

--- a/app/frontend/src/services/authServices.ts
+++ b/app/frontend/src/services/authServices.ts
@@ -3,15 +3,19 @@ import { Token } from "../types/Token.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 
 export async function authAndDecodeAccessToken(): Promise<ApiResponse<Token>> {
-  return apiFetch<Token>("/api/auth/token", {
+  const url = "/api/auth/token";
+
+  return apiFetch<Token>(url, {
     method: "GET",
     credentials: "same-origin"
   });
 }
 
 export async function refreshAccessToken(): Promise<ApiResponse<null>> {
+  const url = "/api/auth/refresh";
+
   return apiFetch<null>(
-    "/api/auth/refresh",
+    url,
     {
       method: "GET",
       credentials: "same-origin"
@@ -24,8 +28,10 @@ export async function userLogin(
   usernameOrEmail: string,
   password: string
 ): Promise<ApiResponse<{ username: string }>> {
+  const url = "/api/auth/login";
+
   return apiFetch<{ username: string }>(
-    "/api/auth/login",
+    url,
     {
       method: "POST",
       credentials: "same-origin",
@@ -36,8 +42,10 @@ export async function userLogin(
 }
 
 export async function userLogout(): Promise<ApiResponse<{ username: string }>> {
+  const url = "/api/auth/logout";
+
   return apiFetch<{ username: string }>(
-    "/api/auth/logout",
+    url,
     {
       method: "PATCH",
       credentials: "same-origin"

--- a/app/frontend/src/services/authServices.ts
+++ b/app/frontend/src/services/authServices.ts
@@ -1,18 +1,19 @@
 import { apiFetch } from "./api.js";
 import { Token } from "../types/Token.js";
+import { ApiResponse } from "../types/IApiResponse.js";
 
-export async function authAndDecodeAccessToken(): Promise<Token> {
+export async function authAndDecodeAccessToken(): Promise<ApiResponse<Token>> {
   const apiResponse = await apiFetch<Token>("/api/auth/token", {
     method: "GET",
     credentials: "same-origin"
   });
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
 export async function refreshAccessToken() {
-  const apiResponse = await apiFetch(
+  const apiResponse = await apiFetch<null>(
     "/api/auth/refresh",
     {
       method: "GET",
@@ -22,12 +23,13 @@ export async function refreshAccessToken() {
   );
 
   console.log(apiResponse);
+  return apiResponse;
 }
 
 export async function userLogin(
   usernameOrEmail: string,
   password: string
-): Promise<{ username: string }> {
+): Promise<ApiResponse<{ username: string }>> {
   const apiResponse = await apiFetch<{ username: string }>("/api/auth/login", {
     method: "POST",
     credentials: "same-origin",
@@ -35,10 +37,10 @@ export async function userLogin(
   });
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
-export async function userLogout(): Promise<{ username: string }> {
+export async function userLogout(): Promise<ApiResponse<{ username: string }>> {
   const apiResponse = await apiFetch<{ username: string }>(
     "/api/auth/logout",
     {
@@ -49,5 +51,5 @@ export async function userLogout(): Promise<{ username: string }> {
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }

--- a/app/frontend/src/services/friendsServices.ts
+++ b/app/frontend/src/services/friendsServices.ts
@@ -5,7 +5,9 @@ import { ApiResponse } from "../types/IApiResponse.js";
 export async function createFriendRequest(
   receiverId: number
 ): Promise<ApiResponse<FriendRequest>> {
-  return apiFetch<FriendRequest>("/api/users/me/friend-requests", {
+  const url = "/api/users/me/friend-requests";
+
+  return apiFetch<FriendRequest>(url, {
     method: "POST",
     body: JSON.stringify({ id: receiverId }),
     credentials: "same-origin"
@@ -15,47 +17,35 @@ export async function createFriendRequest(
 export async function getUserFriendRequests(): Promise<
   ApiResponse<FriendRequest[]>
 > {
-  const apiResponse = await apiFetch<FriendRequest[]>(
-    "/api/users/me/friend-requests",
-    {
-      method: "GET",
-      credentials: "same-origin"
-    }
-  );
+  const url = "/api/users/me/friend-requests";
 
-  console.log(apiResponse);
-  return apiResponse;
+  return apiFetch<FriendRequest[]>(url, {
+    method: "GET",
+    credentials: "same-origin"
+  });
 }
 
 export async function acceptFriendRequest(
   requestId: number
 ): Promise<ApiResponse<FriendRequest>> {
-  const apiResponse = await apiFetch<FriendRequest>(
-    `/api/users/me/friend-requests/${requestId}`,
-    {
-      method: "PATCH",
-      body: JSON.stringify({ status: "ACCEPTED" }),
-      credentials: "same-origin"
-    }
-  );
+  const url = `/api/users/me/friend-requests/${requestId}`;
 
-  console.log(apiResponse);
-  return apiResponse;
+  return apiFetch<FriendRequest>(url, {
+    method: "PATCH",
+    body: JSON.stringify({ status: "ACCEPTED" }),
+    credentials: "same-origin"
+  });
 }
 
 export async function deleteFriendRequest(
   requestId: number
 ): Promise<ApiResponse<FriendRequest>> {
-  const apiResponse = await apiFetch<FriendRequest>(
-    `/api/users/me/friend-requests/${requestId}`,
-    {
-      method: "DELETE",
-      credentials: "same-origin"
-    }
-  );
+  const url = `/api/users/me/friend-requests/${requestId}`;
 
-  console.log(apiResponse);
-  return apiResponse;
+  return apiFetch<FriendRequest>(url, {
+    method: "DELETE",
+    credentials: "same-origin"
+  });
 }
 
 export async function getUserFriendRequestByUsername(
@@ -64,11 +54,8 @@ export async function getUserFriendRequestByUsername(
   const encoded = encodeURIComponent(username);
   const url = `/api/users/me/friend-requests?username=${encoded}`;
 
-  const apiResponse = await apiFetch<FriendRequest[]>(url, {
+  return apiFetch<FriendRequest[]>(url, {
     method: "GET",
     credentials: "same-origin"
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }

--- a/app/frontend/src/services/friendsServices.ts
+++ b/app/frontend/src/services/friendsServices.ts
@@ -5,20 +5,16 @@ import { ApiResponse } from "../types/IApiResponse.js";
 export async function createFriendRequest(
   receiverId: number
 ): Promise<ApiResponse<FriendRequest>> {
-  const apiResponse = await apiFetch<FriendRequest>(
-    "/api/users/me/friend-requests",
-    {
-      method: "POST",
-      body: JSON.stringify({ id: receiverId }),
-      credentials: "same-origin"
-    }
-  );
-
-  console.log(apiResponse);
-  return apiResponse;
+  return apiFetch<FriendRequest>("/api/users/me/friend-requests", {
+    method: "POST",
+    body: JSON.stringify({ id: receiverId }),
+    credentials: "same-origin"
+  });
 }
 
-export async function getUserFriendRequests(): Promise<ApiResponse<FriendRequest[]>> {
+export async function getUserFriendRequests(): Promise<
+  ApiResponse<FriendRequest[]>
+> {
   const apiResponse = await apiFetch<FriendRequest[]>(
     "/api/users/me/friend-requests",
     {

--- a/app/frontend/src/services/friendsServices.ts
+++ b/app/frontend/src/services/friendsServices.ts
@@ -1,9 +1,10 @@
 import { apiFetch } from "./api.js";
 import { FriendRequest } from "../types/FriendRequest.js";
+import { ApiResponse } from "../types/IApiResponse.js";
 
 export async function createFriendRequest(
   receiverId: number
-): Promise<FriendRequest> {
+): Promise<ApiResponse<FriendRequest>> {
   const apiResponse = await apiFetch<FriendRequest>(
     "/api/users/me/friend-requests",
     {
@@ -14,10 +15,10 @@ export async function createFriendRequest(
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
-export async function getUserFriendRequests(): Promise<FriendRequest[]> {
+export async function getUserFriendRequests(): Promise<ApiResponse<FriendRequest[]>> {
   const apiResponse = await apiFetch<FriendRequest[]>(
     "/api/users/me/friend-requests",
     {
@@ -27,12 +28,12 @@ export async function getUserFriendRequests(): Promise<FriendRequest[]> {
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
 export async function acceptFriendRequest(
   requestId: number
-): Promise<FriendRequest> {
+): Promise<ApiResponse<FriendRequest>> {
   const apiResponse = await apiFetch<FriendRequest>(
     `/api/users/me/friend-requests/${requestId}`,
     {
@@ -43,12 +44,12 @@ export async function acceptFriendRequest(
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
 export async function deleteFriendRequest(
   requestId: number
-): Promise<FriendRequest> {
+): Promise<ApiResponse<FriendRequest>> {
   const apiResponse = await apiFetch<FriendRequest>(
     `/api/users/me/friend-requests/${requestId}`,
     {
@@ -58,12 +59,12 @@ export async function deleteFriendRequest(
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
 export async function getUserFriendRequestByUsername(
   username: string
-): Promise<FriendRequest | null> {
+): Promise<ApiResponse<FriendRequest[]>> {
   const encoded = encodeURIComponent(username);
   const url = `/api/users/me/friend-requests?username=${encoded}`;
 
@@ -72,9 +73,6 @@ export async function getUserFriendRequestByUsername(
     credentials: "same-origin"
   });
 
-  if (!apiResponse.data.length) {
-    return null;
-  }
-
-  return apiResponse.data[0];
+  console.log(apiResponse);
+  return apiResponse;
 }

--- a/app/frontend/src/services/matchServices.ts
+++ b/app/frontend/src/services/matchServices.ts
@@ -3,12 +3,9 @@ import { Match } from "../types/IMatch.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 
 export async function createMatch(match: Match): Promise<ApiResponse<Match>> {
-  const apiResponse = await apiFetch<Match>("/api/matches", {
+  return apiFetch<Match>("/api/matches", {
     method: "POST",
     body: JSON.stringify(match),
     credentials: "same-origin"
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }

--- a/app/frontend/src/services/matchServices.ts
+++ b/app/frontend/src/services/matchServices.ts
@@ -3,7 +3,9 @@ import { Match } from "../types/IMatch.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 
 export async function createMatch(match: Match): Promise<ApiResponse<Match>> {
-  return apiFetch<Match>("/api/matches", {
+  const url = "/api/matches";
+
+  return apiFetch<Match>(url, {
     method: "POST",
     body: JSON.stringify(match),
     credentials: "same-origin"

--- a/app/frontend/src/services/matchServices.ts
+++ b/app/frontend/src/services/matchServices.ts
@@ -1,7 +1,8 @@
 import { apiFetch } from "./api.js";
 import { Match } from "../types/IMatch.js";
+import { ApiResponse } from "../types/IApiResponse.js";
 
-export async function createMatch(match: Match): Promise<Match> {
+export async function createMatch(match: Match): Promise<ApiResponse<Match>> {
   const apiResponse = await apiFetch<Match>("/api/matches", {
     method: "POST",
     body: JSON.stringify(match),
@@ -9,5 +10,5 @@ export async function createMatch(match: Match): Promise<Match> {
   });
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }

--- a/app/frontend/src/services/tournamentService.ts
+++ b/app/frontend/src/services/tournamentService.ts
@@ -1,22 +1,23 @@
 import { Tournament } from "../Tournament.js";
 import { TournamentDTO } from "../types/ITournament.js";
 import { apiFetch } from "./api.js";
+import { ApiResponse } from "../types/IApiResponse.js";
 
 export async function createTournament(
   tournament: Tournament
-): Promise<TournamentDTO> {
+): Promise<ApiResponse<TournamentDTO>> {
   const apiResponse = await apiFetch<TournamentDTO>("/api/tournaments", {
     method: "POST",
     body: JSON.stringify(tournament) // uses toJSON()
   });
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
 export async function setTournamentFinished(
   tournamentId: number
-): Promise<TournamentDTO> {
+): Promise<ApiResponse<TournamentDTO>> {
   const apiResponse = await apiFetch<TournamentDTO>(
     `/api/tournaments/${tournamentId}`,
     {
@@ -26,12 +27,12 @@ export async function setTournamentFinished(
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
 export async function updateTournamentBracket(
   tournament: Tournament
-): Promise<TournamentDTO> {
+): Promise<ApiResponse<TournamentDTO>> {
   const tournamentId = tournament.getId();
   const apiResponse = await apiFetch<TournamentDTO>(
     `/api/tournaments/${tournamentId}`,
@@ -42,10 +43,10 @@ export async function updateTournamentBracket(
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
-export async function getUserTournaments(): Promise<TournamentDTO[]> {
+export async function getUserTournaments(): Promise<ApiResponse<TournamentDTO[]>> {
   const apiResponse = await apiFetch<TournamentDTO[]>(
     "/api/users/me/tournaments",
     {
@@ -55,10 +56,10 @@ export async function getUserTournaments(): Promise<TournamentDTO[]> {
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
-export async function getActiveTournament(): Promise<TournamentDTO | null> {
+export async function getActiveTournament(): Promise<ApiResponse<TournamentDTO | null>> {
   const apiResponse = await apiFetch<TournamentDTO | null>(
     `/api/users/me/tournaments/active`,
     {
@@ -67,14 +68,14 @@ export async function getActiveTournament(): Promise<TournamentDTO | null> {
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
-export async function deleteTournament(id: number): Promise<TournamentDTO> {
+export async function deleteTournament(id: number): Promise<ApiResponse<TournamentDTO>> {
   const apiResponse = await apiFetch<TournamentDTO>(`/api/tournaments/${id}`, {
     method: "DELETE"
   });
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }

--- a/app/frontend/src/services/tournamentService.ts
+++ b/app/frontend/src/services/tournamentService.ts
@@ -6,76 +6,53 @@ import { ApiResponse } from "../types/IApiResponse.js";
 export async function createTournament(
   tournament: Tournament
 ): Promise<ApiResponse<TournamentDTO>> {
-  const apiResponse = await apiFetch<TournamentDTO>("/api/tournaments", {
+  return apiFetch<TournamentDTO>("/api/tournaments", {
     method: "POST",
     body: JSON.stringify(tournament) // uses toJSON()
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function setTournamentFinished(
   tournamentId: number
 ): Promise<ApiResponse<TournamentDTO>> {
-  const apiResponse = await apiFetch<TournamentDTO>(
-    `/api/tournaments/${tournamentId}`,
-    {
-      method: "PATCH",
-      body: JSON.stringify({ status: "FINISHED" })
-    }
-  );
-
-  console.log(apiResponse);
-  return apiResponse;
+  return apiFetch<TournamentDTO>(`/api/tournaments/${tournamentId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ status: "FINISHED" })
+  });
 }
 
 export async function updateTournamentBracket(
   tournament: Tournament
 ): Promise<ApiResponse<TournamentDTO>> {
   const tournamentId = tournament.getId();
-  const apiResponse = await apiFetch<TournamentDTO>(
-    `/api/tournaments/${tournamentId}`,
-    {
-      method: "PATCH",
-      body: JSON.stringify({ bracket: JSON.stringify(tournament.getBracket()) })
-    }
-  );
 
-  console.log(apiResponse);
-  return apiResponse;
+  return apiFetch<TournamentDTO>(`/api/tournaments/${tournamentId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ bracket: JSON.stringify(tournament.getBracket()) })
+  });
 }
 
-export async function getUserTournaments(): Promise<ApiResponse<TournamentDTO[]>> {
-  const apiResponse = await apiFetch<TournamentDTO[]>(
-    "/api/users/me/tournaments",
-    {
-      method: "GET",
-      credentials: "same-origin"
-    }
-  );
-
-  console.log(apiResponse);
-  return apiResponse;
+export async function getUserTournaments(): Promise<
+  ApiResponse<TournamentDTO[]>
+> {
+  return apiFetch<TournamentDTO[]>("/api/users/me/tournaments", {
+    method: "GET",
+    credentials: "same-origin"
+  });
 }
 
-export async function getActiveTournament(): Promise<ApiResponse<TournamentDTO | null>> {
-  const apiResponse = await apiFetch<TournamentDTO | null>(
-    `/api/users/me/tournaments/active`,
-    {
-      method: "GET"
-    }
-  );
-
-  console.log(apiResponse);
-  return apiResponse;
+export async function getActiveTournament(): Promise<
+  ApiResponse<TournamentDTO | null>
+> {
+  return apiFetch<TournamentDTO | null>(`/api/users/me/tournaments/active`, {
+    method: "GET"
+  });
 }
 
-export async function deleteTournament(id: number): Promise<ApiResponse<TournamentDTO>> {
-  const apiResponse = await apiFetch<TournamentDTO>(`/api/tournaments/${id}`, {
+export async function deleteTournament(
+  id: number
+): Promise<ApiResponse<TournamentDTO>> {
+  return apiFetch<TournamentDTO>(`/api/tournaments/${id}`, {
     method: "DELETE"
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }

--- a/app/frontend/src/services/tournamentService.ts
+++ b/app/frontend/src/services/tournamentService.ts
@@ -6,7 +6,9 @@ import { ApiResponse } from "../types/IApiResponse.js";
 export async function createTournament(
   tournament: Tournament
 ): Promise<ApiResponse<TournamentDTO>> {
-  return apiFetch<TournamentDTO>("/api/tournaments", {
+  const url = "/api/tournaments";
+
+  return apiFetch<TournamentDTO>(url, {
     method: "POST",
     body: JSON.stringify(tournament) // uses toJSON()
   });
@@ -15,7 +17,9 @@ export async function createTournament(
 export async function setTournamentFinished(
   tournamentId: number
 ): Promise<ApiResponse<TournamentDTO>> {
-  return apiFetch<TournamentDTO>(`/api/tournaments/${tournamentId}`, {
+  const url = `/api/tournaments/${tournamentId}`;
+
+  return apiFetch<TournamentDTO>(url, {
     method: "PATCH",
     body: JSON.stringify({ status: "FINISHED" })
   });
@@ -25,8 +29,9 @@ export async function updateTournamentBracket(
   tournament: Tournament
 ): Promise<ApiResponse<TournamentDTO>> {
   const tournamentId = tournament.getId();
+  const url = `/api/tournaments/${tournamentId}`;
 
-  return apiFetch<TournamentDTO>(`/api/tournaments/${tournamentId}`, {
+  return apiFetch<TournamentDTO>(url, {
     method: "PATCH",
     body: JSON.stringify({ bracket: JSON.stringify(tournament.getBracket()) })
   });
@@ -35,7 +40,9 @@ export async function updateTournamentBracket(
 export async function getUserTournaments(): Promise<
   ApiResponse<TournamentDTO[]>
 > {
-  return apiFetch<TournamentDTO[]>("/api/users/me/tournaments", {
+  const url = "/api/users/me/tournaments";
+
+  return apiFetch<TournamentDTO[]>(url, {
     method: "GET",
     credentials: "same-origin"
   });
@@ -44,7 +51,9 @@ export async function getUserTournaments(): Promise<
 export async function getActiveTournament(): Promise<
   ApiResponse<TournamentDTO | null>
 > {
-  return apiFetch<TournamentDTO | null>(`/api/users/me/tournaments/active`, {
+  const url = `/api/users/me/tournaments/active`;
+
+  return apiFetch<TournamentDTO | null>(url, {
     method: "GET"
   });
 }
@@ -52,7 +61,9 @@ export async function getActiveTournament(): Promise<
 export async function deleteTournament(
   id: number
 ): Promise<ApiResponse<TournamentDTO>> {
-  return apiFetch<TournamentDTO>(`/api/tournaments/${id}`, {
+  const url = `/api/tournaments/${id}`;
+
+  return apiFetch<TournamentDTO>(url, {
     method: "DELETE"
   });
 }

--- a/app/frontend/src/services/userServices.ts
+++ b/app/frontend/src/services/userServices.ts
@@ -1,8 +1,9 @@
 import { apiFetch } from "./api.js";
 import { Match } from "../types/IMatch.js";
 import { User } from "../types/User.js";
+import { ApiResponse } from "../types/IApiResponse.js";
 
-export async function getUserPlayedMatches(): Promise<Match[]> {
+export async function getUserPlayedMatches(): Promise<ApiResponse<Match[]>> {
   const apiResponse = await apiFetch<Match[]>(
     "/api/users/me/matches?playedAs=PLAYERONE&playedAs=PLAYERTWO",
     {
@@ -12,20 +13,20 @@ export async function getUserPlayedMatches(): Promise<Match[]> {
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
-export async function getUserProfile(): Promise<User> {
+export async function getUserProfile(): Promise<ApiResponse<User>> {
   const apiResponse = await apiFetch<User>("/api/users/me", {
     method: "GET",
     credentials: "same-origin"
   });
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
-export async function patchUser(updateData: Partial<User>): Promise<User> {
+export async function patchUser(updateData: Partial<User>): Promise<ApiResponse<User>> {
   const apiResponse = await apiFetch<User>("/api/users/me", {
     method: "PATCH",
     body: JSON.stringify(updateData),
@@ -33,10 +34,10 @@ export async function patchUser(updateData: Partial<User>): Promise<User> {
   });
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
-export async function uploadAvatar(formData: FormData): Promise<User> {
+export async function uploadAvatar(formData: FormData): Promise<ApiResponse<User>> {
   const apiResponse = await apiFetch<User>("/api/users/me/avatar", {
     method: "POST",
     body: formData,
@@ -44,16 +45,16 @@ export async function uploadAvatar(formData: FormData): Promise<User> {
   });
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
-export async function deleteUserAvatar(): Promise<User> {
+export async function deleteUserAvatar(): Promise<ApiResponse<User>> {
   const apiResponse = await apiFetch<User>("/api/users/me/avatar", {
     method: "DELETE",
     credentials: "same-origin"
   });
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
 export async function registerUser(
@@ -66,12 +67,12 @@ export async function registerUser(
     body: JSON.stringify({ email, username, password })
   });
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
 export async function getUserByUsername(
   username: string
-): Promise<User | null> {
+): Promise<ApiResponse<User | null>> {
   const apiResponse = await apiFetch<User | null>(
     `/api/users/search?username=${encodeURIComponent(username)}`,
     {
@@ -81,12 +82,12 @@ export async function getUserByUsername(
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
 export async function getUserByEmail(
   email: string
-): Promise<User | null> {
+): Promise<ApiResponse<User | null>> {
   const apiResponse = await apiFetch<User | null>(
     `/api/users/search?email=${encodeURIComponent(email)}`,
     {
@@ -96,12 +97,12 @@ export async function getUserByEmail(
   );
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
 export async function getUserPlayedMatchesByUsername(
   username: string
-): Promise<Match[]> {
+): Promise<ApiResponse<Match[]>> {
   const encoded = encodeURIComponent(username);
   const url = `/api/users/${encoded}/matches?playedAs=PLAYERONE&playedAs=PLAYERTWO`;
 
@@ -111,10 +112,10 @@ export async function getUserPlayedMatchesByUsername(
   });
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
-export async function updateUserPassword(currentPassword: string, newPassword: string): Promise<void> {
+export async function updateUserPassword(currentPassword: string, newPassword: string) {
   const apiResponse = await apiFetch<User>("/api/users/me/password", {
     method: "PATCH",
     body: JSON.stringify({ currentPassword, newPassword }),
@@ -122,4 +123,5 @@ export async function updateUserPassword(currentPassword: string, newPassword: s
   });
 
   console.log(apiResponse);
+  return apiResponse;
 }

--- a/app/frontend/src/services/userServices.ts
+++ b/app/frontend/src/services/userServices.ts
@@ -4,32 +4,41 @@ import { User } from "../types/User.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 
 export async function getUserPlayedMatches(): Promise<ApiResponse<Match[]>> {
-  return apiFetch<Match[]>(
-    "/api/users/me/matches?playedAs=PLAYERONE&playedAs=PLAYERTWO",
-    {
-      method: "GET",
-      credentials: "same-origin"
-    }
-  );
-}
+  const url = "/api/users/me/matches?playedAs=PLAYERONE&playedAs=PLAYERTWO";
 
-export async function getUserProfile(): Promise<ApiResponse<User>> {
-  return apiFetch<User>("/api/users/me", {
+  return apiFetch<Match[]>(url, {
     method: "GET",
     credentials: "same-origin"
   });
 }
 
-export async function patchUser(updateData: Partial<User>): Promise<ApiResponse<User>> {
-  return  apiFetch<User>("/api/users/me", {
+export async function getUserProfile(): Promise<ApiResponse<User>> {
+  const url = "/api/users/me";
+
+  return apiFetch<User>(url, {
+    method: "GET",
+    credentials: "same-origin"
+  });
+}
+
+export async function patchUser(
+  updateData: Partial<User>
+): Promise<ApiResponse<User>> {
+  const url = "/api/users/me";
+
+  return apiFetch<User>(url, {
     method: "PATCH",
     body: JSON.stringify(updateData),
     credentials: "same-origin"
   });
 }
 
-export async function uploadAvatar(formData: FormData): Promise<ApiResponse<User>> {
-  return apiFetch<User>("/api/users/me/avatar", {
+export async function uploadAvatar(
+  formData: FormData
+): Promise<ApiResponse<User>> {
+  const url = "/api/users/me/avatar";
+
+  return apiFetch<User>(url, {
     method: "POST",
     body: formData,
     credentials: "same-origin"
@@ -37,7 +46,9 @@ export async function uploadAvatar(formData: FormData): Promise<ApiResponse<User
 }
 
 export async function deleteUserAvatar(): Promise<ApiResponse<User>> {
-  return apiFetch<User>("/api/users/me/avatar", {
+  const url = "/api/users/me/avatar";
+
+  return apiFetch<User>(url, {
     method: "DELETE",
     credentials: "same-origin"
   });
@@ -48,7 +59,9 @@ export async function registerUser(
   username: string,
   password: string
 ) {
-  return apiFetch<User>("api/users/", {
+  const url = "api/users/";
+
+  return apiFetch<User>(url, {
     method: "POST",
     body: JSON.stringify({ email, username, password })
   });
@@ -57,25 +70,23 @@ export async function registerUser(
 export async function getUserByUsername(
   username: string
 ): Promise<ApiResponse<User | null>> {
-  return apiFetch<User | null>(
-    `/api/users/search?username=${encodeURIComponent(username)}`,
-    {
-      method: "GET",
-      credentials: "same-origin"
-    }
-  );
+  const url = `/api/users/search?username=${encodeURIComponent(username)}`;
+
+  return apiFetch<User | null>(url, {
+    method: "GET",
+    credentials: "same-origin"
+  });
 }
 
 export async function getUserByEmail(
   email: string
 ): Promise<ApiResponse<User | null>> {
-  return apiFetch<User | null>(
-    `/api/users/search?email=${encodeURIComponent(email)}`,
-    {
-      method: "GET",
-      credentials: "same-origin"
-    }
-  );
+  const url = `/api/users/search?email=${encodeURIComponent(email)}`;
+
+  return apiFetch<User | null>(url, {
+    method: "GET",
+    credentials: "same-origin"
+  });
 }
 
 export async function getUserPlayedMatchesByUsername(
@@ -90,8 +101,13 @@ export async function getUserPlayedMatchesByUsername(
   });
 }
 
-export async function updateUserPassword(currentPassword: string, newPassword: string) {
-  return apiFetch<User>("/api/users/me/password", {
+export async function updateUserPassword(
+  currentPassword: string,
+  newPassword: string
+) {
+  const url = "/api/users/me/password";
+
+  return apiFetch<User>(url, {
     method: "PATCH",
     body: JSON.stringify({ currentPassword, newPassword }),
     credentials: "same-origin"

--- a/app/frontend/src/services/userServices.ts
+++ b/app/frontend/src/services/userServices.ts
@@ -58,7 +58,7 @@ export async function registerUser(
   email: string,
   username: string,
   password: string
-) {
+): Promise<ApiResponse<User>> {
   const url = "api/users/";
 
   return apiFetch<User>(url, {
@@ -104,7 +104,7 @@ export async function getUserPlayedMatchesByUsername(
 export async function updateUserPassword(
   currentPassword: string,
   newPassword: string
-) {
+): Promise<ApiResponse<User>> {
   const url = "/api/users/me/password";
 
   return apiFetch<User>(url, {

--- a/app/frontend/src/services/userServices.ts
+++ b/app/frontend/src/services/userServices.ts
@@ -4,57 +4,43 @@ import { User } from "../types/User.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 
 export async function getUserPlayedMatches(): Promise<ApiResponse<Match[]>> {
-  const apiResponse = await apiFetch<Match[]>(
+  return apiFetch<Match[]>(
     "/api/users/me/matches?playedAs=PLAYERONE&playedAs=PLAYERTWO",
     {
       method: "GET",
       credentials: "same-origin"
     }
   );
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function getUserProfile(): Promise<ApiResponse<User>> {
-  const apiResponse = await apiFetch<User>("/api/users/me", {
+  return apiFetch<User>("/api/users/me", {
     method: "GET",
     credentials: "same-origin"
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function patchUser(updateData: Partial<User>): Promise<ApiResponse<User>> {
-  const apiResponse = await apiFetch<User>("/api/users/me", {
+  return  apiFetch<User>("/api/users/me", {
     method: "PATCH",
     body: JSON.stringify(updateData),
     credentials: "same-origin"
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function uploadAvatar(formData: FormData): Promise<ApiResponse<User>> {
-  const apiResponse = await apiFetch<User>("/api/users/me/avatar", {
+  return apiFetch<User>("/api/users/me/avatar", {
     method: "POST",
     body: formData,
     credentials: "same-origin"
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function deleteUserAvatar(): Promise<ApiResponse<User>> {
-  const apiResponse = await apiFetch<User>("/api/users/me/avatar", {
+  return apiFetch<User>("/api/users/me/avatar", {
     method: "DELETE",
     credentials: "same-origin"
   });
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function registerUser(
@@ -62,42 +48,34 @@ export async function registerUser(
   username: string,
   password: string
 ) {
-  const apiResponse = await apiFetch<User>("api/users/", {
+  return apiFetch<User>("api/users/", {
     method: "POST",
     body: JSON.stringify({ email, username, password })
   });
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function getUserByUsername(
   username: string
 ): Promise<ApiResponse<User | null>> {
-  const apiResponse = await apiFetch<User | null>(
+  return apiFetch<User | null>(
     `/api/users/search?username=${encodeURIComponent(username)}`,
     {
       method: "GET",
       credentials: "same-origin"
     }
   );
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function getUserByEmail(
   email: string
 ): Promise<ApiResponse<User | null>> {
-  const apiResponse = await apiFetch<User | null>(
+  return apiFetch<User | null>(
     `/api/users/search?email=${encodeURIComponent(email)}`,
     {
       method: "GET",
       credentials: "same-origin"
     }
   );
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function getUserPlayedMatchesByUsername(
@@ -106,22 +84,16 @@ export async function getUserPlayedMatchesByUsername(
   const encoded = encodeURIComponent(username);
   const url = `/api/users/${encoded}/matches?playedAs=PLAYERONE&playedAs=PLAYERTWO`;
 
-  const apiResponse = await apiFetch<Match[]>(url, {
+  return apiFetch<Match[]>(url, {
     method: "GET",
     credentials: "same-origin"
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function updateUserPassword(currentPassword: string, newPassword: string) {
-  const apiResponse = await apiFetch<User>("/api/users/me/password", {
+  return apiFetch<User>("/api/users/me/password", {
     method: "PATCH",
     body: JSON.stringify({ currentPassword, newPassword }),
     credentials: "same-origin"
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }

--- a/app/frontend/src/services/userStatsServices.ts
+++ b/app/frontend/src/services/userStatsServices.ts
@@ -1,19 +1,20 @@
 import { apiFetch } from "./api.js";
 import { UserStats } from "../types/IUserStats.js";
+import { ApiResponse } from "../types/IApiResponse.js";
 
-export async function getUserStats(): Promise<UserStats> {
+export async function getUserStats(): Promise<ApiResponse<UserStats>> {
   const apiResponse = await apiFetch<UserStats>(`/api/users/me/user-stats`, {
     method: "GET",
     credentials: "same-origin"
   });
 
   console.log(apiResponse);
-  return apiResponse.data;
+  return apiResponse;
 }
 
 export async function getUserStatsByUsername(
   username: string
-): Promise<UserStats | null> {
+): Promise<ApiResponse<UserStats[]>> {
   const encoded = encodeURIComponent(username);
   const url = `/api/user-stats/?username=${encoded}`;
 
@@ -22,9 +23,6 @@ export async function getUserStatsByUsername(
     credentials: "same-origin"
   });
 
-  if (!apiResponse.data.length) {
-    return null;
-  }
-
-  return apiResponse.data[0];
+  console.log(apiResponse);
+  return apiResponse;
 }

--- a/app/frontend/src/services/userStatsServices.ts
+++ b/app/frontend/src/services/userStatsServices.ts
@@ -3,7 +3,9 @@ import { UserStats } from "../types/IUserStats.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 
 export async function getUserStats(): Promise<ApiResponse<UserStats>> {
-  return apiFetch<UserStats>(`/api/users/me/user-stats`, {
+  const url = `/api/users/me/user-stats`;
+
+  return apiFetch<UserStats>(url, {
     method: "GET",
     credentials: "same-origin"
   });

--- a/app/frontend/src/services/userStatsServices.ts
+++ b/app/frontend/src/services/userStatsServices.ts
@@ -3,13 +3,10 @@ import { UserStats } from "../types/IUserStats.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 
 export async function getUserStats(): Promise<ApiResponse<UserStats>> {
-  const apiResponse = await apiFetch<UserStats>(`/api/users/me/user-stats`, {
+  return apiFetch<UserStats>(`/api/users/me/user-stats`, {
     method: "GET",
     credentials: "same-origin"
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }
 
 export async function getUserStatsByUsername(
@@ -18,11 +15,8 @@ export async function getUserStatsByUsername(
   const encoded = encodeURIComponent(username);
   const url = `/api/user-stats/?username=${encoded}`;
 
-  const apiResponse = await apiFetch<UserStats[]>(url, {
+  return apiFetch<UserStats[]>(url, {
     method: "GET",
     credentials: "same-origin"
   });
-
-  console.log(apiResponse);
-  return apiResponse;
 }

--- a/app/frontend/src/types/IApiResponse.ts
+++ b/app/frontend/src/types/IApiResponse.ts
@@ -1,8 +1,14 @@
-export interface ApiResponse<T> {
+export type ApiResponse<T> = ApiSuccess<T> | ApiFail;
+
+export type ApiSuccess<T> = {
+  success: true;
   message: string;
   data: T;
-}
+};
 
-export interface ExtendedApiResponse<T> extends ApiResponse<T> {
-  count: number;
-}
+export type ApiFail = {
+  success: false;
+  message: string;
+  status: number;
+  cause?: string;
+};

--- a/app/frontend/src/validate.ts
+++ b/app/frontend/src/validate.ts
@@ -1,3 +1,4 @@
+import { unwrap } from "./services/api.js";
 import { getUserTournaments } from "./services/tournamentService.js";
 import { toaster } from "./Toaster.js";
 
@@ -100,7 +101,7 @@ export async function isTournamentNameAvailable(
   errorEl: HTMLElement
 ): Promise<boolean> {
   try {
-    const tournaments = await getUserTournaments();
+    const tournaments = unwrap(await getUserTournaments());
     if (tournaments.length === 0) {
       return true;
     }

--- a/app/frontend/src/validate.ts
+++ b/app/frontend/src/validate.ts
@@ -1,4 +1,4 @@
-import { unwrap } from "./services/api.js";
+import { getDataOrThrow } from "./services/api.js";
 import { getUserTournaments } from "./services/tournamentService.js";
 import { toaster } from "./Toaster.js";
 
@@ -101,7 +101,7 @@ export async function isTournamentNameAvailable(
   errorEl: HTMLElement
 ): Promise<boolean> {
   try {
-    const tournaments = unwrap(await getUserTournaments());
+    const tournaments = getDataOrThrow(await getUserTournaments());
     if (tournaments.length === 0) {
       return true;
     }

--- a/app/frontend/src/views/FriendsView.ts
+++ b/app/frontend/src/views/FriendsView.ts
@@ -1,6 +1,6 @@
 import { router } from "../routing/Router.js";
 import { sanitizeHTML } from "../sanitize.js";
-import { ApiError } from "../services/api.js";
+import { ApiError, unwrap } from "../services/api.js";
 import {
   deleteFriendRequest,
   getUserFriendRequests,
@@ -41,7 +41,7 @@ export default class FriendsView extends AbstractView {
   }
 
   async render(): Promise<void> {
-    this.friendRequests = await getUserFriendRequests();
+    this.friendRequests = unwrap(await getUserFriendRequests());
     this.updateHTML();
     this.addListeners();
   }
@@ -290,7 +290,7 @@ export default class FriendsView extends AbstractView {
     try {
       const btn = event.currentTarget as HTMLButtonElement;
       const requestId = this.getRequestIdFromButton(btn);
-      const request = await deleteFriendRequest(requestId);
+      const request = unwrap(await deleteFriendRequest(requestId));
       this.removeFriendRequest(request.id);
     } catch (error) {
       router.handleError("Error in handleDeleteButton()", error);
@@ -301,7 +301,7 @@ export default class FriendsView extends AbstractView {
     try {
       const btn = event.currentTarget as HTMLButtonElement;
       const requestid = this.getRequestIdFromButton(btn);
-      const request = await acceptFriendRequest(requestid);
+      const request = unwrap(await acceptFriendRequest(requestid));
       this.removeFriendRequest(request.id);
       this.addFriendRequest(request);
     } catch (error) {
@@ -338,7 +338,7 @@ export default class FriendsView extends AbstractView {
     const username = inputEl.value.trim();
 
     try {
-      const user = await getUserByUsername(username);
+      const user = unwrap(await getUserByUsername(username));
 
       if (user === null) {
         markInvalid("User not found.", inputEl, errorEl);
@@ -346,7 +346,7 @@ export default class FriendsView extends AbstractView {
       }
       clearInvalid(inputEl, errorEl);
 
-      const request = await createFriendRequest(user.id);
+      const request = unwrap(await createFriendRequest(user.id));
       this.removeFriendRequest(request.id);
       this.addFriendRequest(request);
       inputEl.value = "";
@@ -413,18 +413,18 @@ export default class FriendsView extends AbstractView {
       const { requestId, username, status } = customEvent.detail;
       switch (status) {
         case "PENDING": {
-          const request = await getUserFriendRequestByUsername(username);
-          if (request) {
-            this.addFriendRequest(request);
+          const requests = unwrap(await getUserFriendRequestByUsername(username));
+          if (requests[0]) {
+            this.addFriendRequest(requests[0]);
             this.refreshRequestList("incoming");
           }
           break;
         }
         case "ACCEPTED": {
-          const request = await getUserFriendRequestByUsername(username);
-          if (request) {
+          const request = unwrap(await getUserFriendRequestByUsername(username));
+          if (request[0]) {
             this.removeFriendRequest(requestId);
-            this.addFriendRequest(request);
+            this.addFriendRequest(request[0]);
             this.refreshRequestList("friend");
             this.refreshRequestList("outgoing");
           }

--- a/app/frontend/src/views/FriendsView.ts
+++ b/app/frontend/src/views/FriendsView.ts
@@ -1,6 +1,6 @@
 import { router } from "../routing/Router.js";
 import { sanitizeHTML } from "../sanitize.js";
-import { ApiError, unwrap } from "../services/api.js";
+import { unwrap } from "../services/api.js";
 import {
   deleteFriendRequest,
   getUserFriendRequests,
@@ -358,13 +358,7 @@ export default class FriendsView extends AbstractView {
         this.refreshRequestList("friend");
       }
     } catch (error) {
-      console.error(error);
-      let message = "Something went wrong.";
-      if (error instanceof ApiError) {
-        message = error.cause ? error.cause : error.message;
-      }
-      markInvalid(`${message}`, inputEl, errorEl);
-      inputEl.disabled = false;
+      router.handleError("handleSendRequestButton()", error);
     }
   };
 
@@ -413,7 +407,9 @@ export default class FriendsView extends AbstractView {
       const { requestId, username, status } = customEvent.detail;
       switch (status) {
         case "PENDING": {
-          const requests = unwrap(await getUserFriendRequestByUsername(username));
+          const requests = unwrap(
+            await getUserFriendRequestByUsername(username)
+          );
           if (requests[0]) {
             this.addFriendRequest(requests[0]);
             this.refreshRequestList("incoming");
@@ -421,7 +417,9 @@ export default class FriendsView extends AbstractView {
           break;
         }
         case "ACCEPTED": {
-          const request = unwrap(await getUserFriendRequestByUsername(username));
+          const request = unwrap(
+            await getUserFriendRequestByUsername(username)
+          );
           if (request[0]) {
             this.removeFriendRequest(requestId);
             this.addFriendRequest(request[0]);

--- a/app/frontend/src/views/FriendsView.ts
+++ b/app/frontend/src/views/FriendsView.ts
@@ -1,6 +1,6 @@
 import { router } from "../routing/Router.js";
 import { sanitizeHTML } from "../sanitize.js";
-import { unwrap } from "../services/api.js";
+import { getDataOrThrow } from "../services/api.js";
 import {
   deleteFriendRequest,
   getUserFriendRequests,
@@ -41,7 +41,7 @@ export default class FriendsView extends AbstractView {
   }
 
   async render(): Promise<void> {
-    this.friendRequests = unwrap(await getUserFriendRequests());
+    this.friendRequests = getDataOrThrow(await getUserFriendRequests());
     this.updateHTML();
     this.addListeners();
   }
@@ -290,7 +290,7 @@ export default class FriendsView extends AbstractView {
     try {
       const btn = event.currentTarget as HTMLButtonElement;
       const requestId = this.getRequestIdFromButton(btn);
-      const request = unwrap(await deleteFriendRequest(requestId));
+      const request = getDataOrThrow(await deleteFriendRequest(requestId));
       this.removeFriendRequest(request.id);
     } catch (error) {
       router.handleError("Error in handleDeleteButton()", error);
@@ -301,7 +301,7 @@ export default class FriendsView extends AbstractView {
     try {
       const btn = event.currentTarget as HTMLButtonElement;
       const requestid = this.getRequestIdFromButton(btn);
-      const request = unwrap(await acceptFriendRequest(requestid));
+      const request = getDataOrThrow(await acceptFriendRequest(requestid));
       this.removeFriendRequest(request.id);
       this.addFriendRequest(request);
     } catch (error) {
@@ -338,7 +338,7 @@ export default class FriendsView extends AbstractView {
     const username = inputEl.value.trim();
 
     try {
-      const user = unwrap(await getUserByUsername(username));
+      const user = getDataOrThrow(await getUserByUsername(username));
 
       if (user === null) {
         markInvalid("User not found.", inputEl, errorEl);
@@ -346,7 +346,7 @@ export default class FriendsView extends AbstractView {
       }
       clearInvalid(inputEl, errorEl);
 
-      const request = unwrap(await createFriendRequest(user.id));
+      const request = getDataOrThrow(await createFriendRequest(user.id));
       this.removeFriendRequest(request.id);
       this.addFriendRequest(request);
       inputEl.value = "";
@@ -407,7 +407,7 @@ export default class FriendsView extends AbstractView {
       const { requestId, username, status } = customEvent.detail;
       switch (status) {
         case "PENDING": {
-          const requests = unwrap(
+          const requests = getDataOrThrow(
             await getUserFriendRequestByUsername(username)
           );
           if (requests[0]) {
@@ -417,7 +417,7 @@ export default class FriendsView extends AbstractView {
           break;
         }
         case "ACCEPTED": {
-          const request = unwrap(
+          const request = getDataOrThrow(
             await getUserFriendRequestByUsername(username)
           );
           if (request[0]) {

--- a/app/frontend/src/views/MatchAnnouncementView.ts
+++ b/app/frontend/src/views/MatchAnnouncementView.ts
@@ -9,6 +9,7 @@ import { Paragraph } from "../components/Paragraph.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
 import { playedAs } from "../types/IMatch.js";
+import { unwrap } from "../services/api.js";
 
 export default class MatchAnnouncementView extends AbstractView {
   private player1: string;
@@ -118,7 +119,7 @@ export default class MatchAnnouncementView extends AbstractView {
   private async abortTournament() {
     try {
       if (!confirm("Do you really want to abort the tournament?")) return;
-      await deleteTournament(this.tournament.getId());
+      unwrap(await deleteTournament(this.tournament.getId()));
       router.reload();
     } catch (error) {
       router.handleError("Error while deleting tournament", error);

--- a/app/frontend/src/views/MatchAnnouncementView.ts
+++ b/app/frontend/src/views/MatchAnnouncementView.ts
@@ -9,7 +9,7 @@ import { Paragraph } from "../components/Paragraph.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
 import { playedAs } from "../types/IMatch.js";
-import { unwrap } from "../services/api.js";
+import { getDataOrThrow } from "../services/api.js";
 
 export default class MatchAnnouncementView extends AbstractView {
   private player1: string;
@@ -119,7 +119,7 @@ export default class MatchAnnouncementView extends AbstractView {
   private async abortTournament() {
     try {
       if (!confirm("Do you really want to abort the tournament?")) return;
-      unwrap(await deleteTournament(this.tournament.getId()));
+      getDataOrThrow(await deleteTournament(this.tournament.getId()));
       router.reload();
     } catch (error) {
       router.handleError("Error while deleting tournament", error);

--- a/app/frontend/src/views/NewTournamentView.ts
+++ b/app/frontend/src/views/NewTournamentView.ts
@@ -17,6 +17,7 @@ import { Input } from "../components/Input.js";
 import { Button } from "../components/Button.js";
 import { RadioGroup } from "../components/RadioGroup.js";
 import { Form } from "../components/Form.js";
+import { unwrap } from "../services/api.js";
 
 export default class NewTournamentView extends AbstractView {
   private formEl!: HTMLFormElement;
@@ -75,7 +76,7 @@ export default class NewTournamentView extends AbstractView {
   }
 
   async render() {
-    const activeTournament = await getActiveTournament();
+    const activeTournament = unwrap(await getActiveTournament());
     if (!activeTournament) {
       console.log("No active tournament found");
       this.updateHTML();

--- a/app/frontend/src/views/NewTournamentView.ts
+++ b/app/frontend/src/views/NewTournamentView.ts
@@ -17,7 +17,7 @@ import { Input } from "../components/Input.js";
 import { Button } from "../components/Button.js";
 import { RadioGroup } from "../components/RadioGroup.js";
 import { Form } from "../components/Form.js";
-import { unwrap } from "../services/api.js";
+import { getDataOrThrow } from "../services/api.js";
 
 export default class NewTournamentView extends AbstractView {
   private formEl!: HTMLFormElement;
@@ -76,7 +76,7 @@ export default class NewTournamentView extends AbstractView {
   }
 
   async render() {
-    const activeTournament = unwrap(await getActiveTournament());
+    const activeTournament = getDataOrThrow(await getActiveTournament());
     if (!activeTournament) {
       console.log("No active tournament found");
       this.updateHTML();

--- a/app/frontend/src/views/PlayerNicknamesView.ts
+++ b/app/frontend/src/views/PlayerNicknamesView.ts
@@ -11,6 +11,7 @@ import { Header1 } from "../components/Header1.js";
 import { Paragraph } from "../components/Paragraph.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
+import { unwrap } from "../services/api.js";
 
 export default class PlayerNicknamesView extends AbstractView {
   private formEl!: HTMLFormElement;
@@ -89,7 +90,7 @@ export default class PlayerNicknamesView extends AbstractView {
         userId
       );
 
-      const createdTournament = await createTournament(tournament);
+      const createdTournament = unwrap(await createTournament(tournament));
       const { id } = createdTournament;
       if (id) {
         tournament.setId(id);

--- a/app/frontend/src/views/PlayerNicknamesView.ts
+++ b/app/frontend/src/views/PlayerNicknamesView.ts
@@ -11,7 +11,7 @@ import { Header1 } from "../components/Header1.js";
 import { Paragraph } from "../components/Paragraph.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
-import { unwrap } from "../services/api.js";
+import { getDataOrThrow } from "../services/api.js";
 
 export default class PlayerNicknamesView extends AbstractView {
   private formEl!: HTMLFormElement;
@@ -90,7 +90,9 @@ export default class PlayerNicknamesView extends AbstractView {
         userId
       );
 
-      const createdTournament = unwrap(await createTournament(tournament));
+      const createdTournament = getDataOrThrow(
+        await createTournament(tournament)
+      );
       const { id } = createdTournament;
       if (id) {
         tournament.setId(id);

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -223,15 +223,17 @@ export default class ProfileView extends AbstractView {
     };
 
     try {
-      await patchUser(updatedUser);
+      const apiResponse = await patchUser(updatedUser);
+      if (!apiResponse.success) {
+        if (apiResponse.status === 409) {
+          toaster.error("Email or username already exists");
+          return;
+        } else throw new ApiError(apiResponse);
+      }
       toaster.success("Profile updated successfully!");
       auth.updateUser(updatedUser);
       router.reload();
     } catch (err) {
-      if (err instanceof ApiError && err.status === 409) {
-        toaster.error("Email or username already exists");
-        return;
-      }
       toaster.error("Failed to update profile. Please try again.");
       router.handleError("Error in patchUser()", err);
     }
@@ -251,7 +253,7 @@ export default class ProfileView extends AbstractView {
       const { avatar } = unwrap(await uploadAvatar(formData));
       toaster.success("Avatar uploaded successfully!");
       const updatedUser: Partial<User> = {
-        ...(avatar ? { avatar } : {}),
+        ...(avatar ? { avatar } : {})
       };
       auth.updateUser(updatedUser);
       router.reload();

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -21,8 +21,7 @@ import { getInputEl, getEl } from "../utility.js";
 import { patchUser, updateUserPassword } from "../services/userServices.js";
 import { User } from "../types/User.js";
 import { toaster } from "../Toaster.js";
-import { ApiError } from "../services/api.js";
-import { layout } from "../Layout.js";
+import { ApiError, unwrap } from "../services/api.js";
 
 export default class ProfileView extends AbstractView {
   private avatarFormEl!: HTMLFormElement;
@@ -249,7 +248,7 @@ export default class ProfileView extends AbstractView {
     const file = fileInputEl!.files![0];
     formData.append("avatar", file);
     try {
-      const { avatar } = await uploadAvatar(formData);
+      const { avatar } = unwrap(await uploadAvatar(formData));
       toaster.success("Avatar uploaded successfully!");
       const updatedUser: Partial<User> = {
         ...(avatar ? { avatar } : {}),

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -21,7 +21,7 @@ import { getInputEl, getEl } from "../utility.js";
 import { patchUser, updateUserPassword } from "../services/userServices.js";
 import { User } from "../types/User.js";
 import { toaster } from "../Toaster.js";
-import { ApiError, unwrap } from "../services/api.js";
+import { ApiError, getDataOrThrow } from "../services/api.js";
 import { TextBox } from "../components/TextBox.js";
 
 export default class ProfileView extends AbstractView {
@@ -295,7 +295,7 @@ export default class ProfileView extends AbstractView {
     const file = fileInputEl!.files![0];
     formData.append("avatar", file);
     try {
-      const { avatar } = unwrap(await uploadAvatar(formData));
+      const { avatar } = getDataOrThrow(await uploadAvatar(formData));
       toaster.success("Avatar uploaded successfully!");
       const updatedUser: Partial<User> = {
         ...(avatar ? { avatar } : {})
@@ -338,7 +338,7 @@ export default class ProfileView extends AbstractView {
     // }
 
     try {
-      unwrap(
+      getDataOrThrow(
         await updateUserPassword(currentPasswordEl.value, newPasswordEl.value)
       );
       toaster.success("Password updated successfully!");

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -271,7 +271,9 @@ export default class ProfileView extends AbstractView {
         if (apiResponse.status === 409) {
           toaster.error("Email or username already exists");
           return;
-        } else throw new ApiError(apiResponse);
+        } else {
+          throw new ApiError(apiResponse);
+        }
       }
       toaster.success("Profile updated successfully!");
       auth.updateUser(updatedUser);

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -293,7 +293,9 @@ export default class ProfileView extends AbstractView {
     // }
 
     try {
-      await updateUserPassword(currentPasswordEl.value, newPasswordEl.value);
+      unwrap(
+        await updateUserPassword(currentPasswordEl.value, newPasswordEl.value)
+      );
       toaster.success("Password updated successfully!");
       currentPasswordEl.value = "";
       newPasswordEl.value = "";

--- a/app/frontend/src/views/RegisterView.ts
+++ b/app/frontend/src/views/RegisterView.ts
@@ -3,7 +3,7 @@ import {
   validateEmail,
   validateUsername,
   validatePassword,
-  validateConfirmPassword,
+  validateConfirmPassword
 } from "../validate.js";
 import { registerUser } from "../services/userServices.js";
 import { router } from "../routing/Router.js";
@@ -126,12 +126,18 @@ export default class Register extends AbstractView {
     }
 
     try {
-      const apiResponse = await registerUser(emailEL.value, userEl.value, passwordEl.value);
+      const apiResponse = await registerUser(
+        emailEL.value,
+        userEl.value,
+        passwordEl.value
+      );
       if (!apiResponse.success) {
         if (apiResponse.status === 409) {
           toaster.error("Email or username already exists");
           return;
-        } else throw new ApiError(apiResponse);
+        } else {
+          throw new ApiError(apiResponse);
+        }
       }
       const username = escapeHTML(apiResponse.data.username);
       toaster.success(`Successfully registered ${username}`);

--- a/app/frontend/src/views/RegisterView.ts
+++ b/app/frontend/src/views/RegisterView.ts
@@ -126,7 +126,7 @@ export default class Register extends AbstractView {
     }
 
     try {
-      const apiResponse = (await registerUser(emailEL.value, userEl.value, passwordEl.value));
+      const apiResponse = await registerUser(emailEL.value, userEl.value, passwordEl.value);
       if (!apiResponse.success) {
         if (apiResponse.status === 409) {
           toaster.error("Email or username already exists");

--- a/app/frontend/src/views/RegisterView.ts
+++ b/app/frontend/src/views/RegisterView.ts
@@ -8,7 +8,7 @@ import {
 import { registerUser } from "../services/userServices.js";
 import { router } from "../routing/Router.js";
 import { ApiError } from "../services/api.js";
-import { getEl, getInputEl } from "../utility.js";
+import { escapeHTML, getEl, getInputEl } from "../utility.js";
 import { Header1 } from "../components/Header1.js";
 import { addTogglePasswordListener, Input } from "../components/Input.js";
 import { Button } from "../components/Button.js";
@@ -126,14 +126,18 @@ export default class Register extends AbstractView {
     }
 
     try {
-      await registerUser(emailEL.value, userEl.value, passwordEl.value);
-    } catch (error) {
-      if (error instanceof ApiError && error.status === 409) {
-        toaster.error("Email or username already exists");
-        return;
+      const apiResponse = (await registerUser(emailEL.value, userEl.value, passwordEl.value));
+      if (!apiResponse.success) {
+        if (apiResponse.status === 409) {
+          toaster.error("Email or username already exists");
+          return;
+        } else throw new ApiError(apiResponse);
       }
+      const username = escapeHTML(apiResponse.data.username);
+      toaster.success(`Successfully registered ${username}`);
+      router.navigate("/login", false);
+    } catch (error) {
+      router.handleError("validateAndRegisterUser()", error);
     }
-    toaster.info("Registration was successful!");
-    router.navigate("/login", false);
   }
 }

--- a/app/frontend/src/views/ResultsView.ts
+++ b/app/frontend/src/views/ResultsView.ts
@@ -7,6 +7,7 @@ import { Header1 } from "../components/Header1.js";
 import { Header2 } from "../components/Header2.js";
 import { Paragraph } from "../components/Paragraph.js";
 import { Button } from "../components/Button.js";
+import { unwrap } from "../services/api.js";
 
 export default class ResultsView extends AbstractView {
   constructor(private tournament: Tournament) {
@@ -83,7 +84,7 @@ export default class ResultsView extends AbstractView {
 
   private async setFinished() {
     try {
-      await setTournamentFinished(this.tournament.getId());
+      unwrap(await setTournamentFinished(this.tournament.getId()));
       router.reload();
     } catch (error) {
       router.handleError("Error setting tournament as finished", error);

--- a/app/frontend/src/views/ResultsView.ts
+++ b/app/frontend/src/views/ResultsView.ts
@@ -7,7 +7,7 @@ import { Header1 } from "../components/Header1.js";
 import { Header2 } from "../components/Header2.js";
 import { Paragraph } from "../components/Paragraph.js";
 import { Button } from "../components/Button.js";
-import { unwrap } from "../services/api.js";
+import { getDataOrThrow } from "../services/api.js";
 
 export default class ResultsView extends AbstractView {
   constructor(private tournament: Tournament) {
@@ -84,7 +84,7 @@ export default class ResultsView extends AbstractView {
 
   private async setFinished() {
     try {
-      unwrap(await setTournamentFinished(this.tournament.getId()));
+      getDataOrThrow(await setTournamentFinished(this.tournament.getId()));
       router.reload();
     } catch (error) {
       router.handleError("Error setting tournament as finished", error);

--- a/app/frontend/src/views/StatsView.ts
+++ b/app/frontend/src/views/StatsView.ts
@@ -21,6 +21,7 @@ import { User } from "../types/User.js";
 import { UserStats } from "../types/IUserStats.js";
 import { Paragraph } from "../components/Paragraph.js";
 import { StatFieldGroup } from "../components/StatField.js";
+import { unwrap } from "../services/api.js";
 
 export default class StatsView extends AbstractView {
   private viewType: "self" | "friend" | "public" = "public";
@@ -124,12 +125,16 @@ export default class StatsView extends AbstractView {
       this.user = auth.getUser();
       return;
     }
-    this.user = await getUserByUsername(this.username);
+    this.user = unwrap(await getUserByUsername(this.username));
     if (!this.user) {
       throw Error("User not found");
     }
-    this.friendRequest = await getUserFriendRequestByUsername(this.username);
-    if (this.friendRequest?.status === "ACCEPTED") {
+    const requests = unwrap(
+      await getUserFriendRequestByUsername(this.username)
+    );
+    if (!requests[0]) return;
+    this.friendRequest = requests[0];
+    if (this.friendRequest.status === "ACCEPTED") {
       this.viewType = "friend";
     } else {
       this.viewType = "public";
@@ -138,14 +143,17 @@ export default class StatsView extends AbstractView {
 
   async fetchData() {
     if (this.viewType === "self") {
-      this.userStats = await getUserStats();
-      this.matches = await getUserPlayedMatches();
+      this.userStats = unwrap(await getUserStats());
+      this.matches = unwrap(await getUserPlayedMatches());
       return;
     }
-    this.userStats = await getUserStatsByUsername(this.username);
-    if (!this.userStats) throw new Error("Could not fetch user-stats");
+    const userStatsArray = unwrap(await getUserStatsByUsername(this.username));
+    if (!userStatsArray[0]) throw new Error("Could not fetch user-stats");
+    this.userStats = userStatsArray[0];
     if (this.viewType === "friend") {
-      this.matches = await getUserPlayedMatchesByUsername(this.username);
+      this.matches = unwrap(
+        await getUserPlayedMatchesByUsername(this.username)
+      );
     }
   }
 }

--- a/app/frontend/src/views/StatsView.ts
+++ b/app/frontend/src/views/StatsView.ts
@@ -21,7 +21,7 @@ import { User } from "../types/User.js";
 import { UserStats } from "../types/IUserStats.js";
 import { Paragraph } from "../components/Paragraph.js";
 import { StatFieldGroup } from "../components/StatField.js";
-import { unwrap } from "../services/api.js";
+import { getDataOrThrow } from "../services/api.js";
 
 export default class StatsView extends AbstractView {
   private viewType: "self" | "friend" | "public" = "public";
@@ -125,11 +125,11 @@ export default class StatsView extends AbstractView {
       this.user = auth.getUser();
       return;
     }
-    this.user = unwrap(await getUserByUsername(this.username));
+    this.user = getDataOrThrow(await getUserByUsername(this.username));
     if (!this.user) {
       throw Error("User not found");
     }
-    const requests = unwrap(
+    const requests = getDataOrThrow(
       await getUserFriendRequestByUsername(this.username)
     );
     if (!requests[0]) return;
@@ -143,15 +143,17 @@ export default class StatsView extends AbstractView {
 
   async fetchData() {
     if (this.viewType === "self") {
-      this.userStats = unwrap(await getUserStats());
-      this.matches = unwrap(await getUserPlayedMatches());
+      this.userStats = getDataOrThrow(await getUserStats());
+      this.matches = getDataOrThrow(await getUserPlayedMatches());
       return;
     }
-    const userStatsArray = unwrap(await getUserStatsByUsername(this.username));
+    const userStatsArray = getDataOrThrow(
+      await getUserStatsByUsername(this.username)
+    );
     if (!userStatsArray[0]) throw new Error("Could not fetch user-stats");
     this.userStats = userStatsArray[0];
     if (this.viewType === "friend") {
-      this.matches = unwrap(
+      this.matches = getDataOrThrow(
         await getUserPlayedMatchesByUsername(this.username)
       );
     }


### PR DESCRIPTION
### Overview (updated)

1. Implements new error interface
2. new types: ApiSuccess, ApiFail and ApiResponse as union
3. update apiFetch, ApiError (updated)
4. refactor existing service functions
5. implement in codebase

### 1. Implements a new Api error interface

- apiFetch does not automatically throw on HTTP error codes anymore 
- It returns a new union ApiResponse (ApiSuccess | ApiFail), which should be inspected. 
- helper function getDataOrThrow() extracts data, throws ApiError if not possible --> similar to old version
- with `if (apiResponse.success)` we can check what type of ApiResponse we have. Then act on it (e.g. on specific status if ApiFail)
- limitation: if return is not checked in any way (e.g. if not needed) a HTTP error will be silently ignored

Error handling generally work like this (has comments):
```
const apiResponse = await authAndDecodeAccessToken();    // we can't use it directly
if (!apiResponse.success) {    // we need to check. In this if-block it would be ApiFail
  if (apiResponse.status === 401) {    // we can handle this status code
    console.log("JWT validation failed or no token found.");
    return;
  } else throw new ApiError(apiResponse);    // we can't handle anything else -> let router handle it
}
const token = apiResponse.data;    // here we know its ApiSuccess - we can access data
this.user = getDataOrThrow(await getUserProfile());    // we just want the data. If it has error status it throws ApiError
this.updateAuthState(token);
} catch (error) {
  router.handleError("Error while initialize:", error);    // here we display error page
}
```

### 2. new types: ApiSuccess, ApiFail and ApiResponse as union

- ApiResponse is now a discriminated union: it is either ApiSuccess (success: true) or ApiFail (success: false)
- ApiSuccess has message and data T
- ApiFail has message, status, cause
- when working with ApiResponse, we need to check what type it is

### 3. update apiFetch, ApiError (updated)

- new helper functions createApiSuccess() and createApiFail() which construct ApiSuccess or ApiFail
- ~~only throws if fetch itself throws.~~ It always returns an ApiResponse (= ApiSuccess | ApiFail). If fetch itself throws an Internal Server error is returned
- centralized logging of ApiResponse into success() and failure()
- adapted refresh logic, since apiFetch does not throw anymore: 
  - if refresh fails checks if it failed with 401: if so calls `auth.clearTokenOnError();`
  - `clearTokenOnError()` checks if user is authenticated. If so error toasts and clears auth state
  - user would not be authenticated on initial page load where we also check for access and refresh token
  - `router.handleError()` checks if status === 401 - if yes does nothing
- ApiError can now be constructed with ApiFail for convenience > handle specific status codes, throw for everything else

### 4. refactor existing service functions

- adapt return type to ApiResponse\<T\>
- some functions did not have return --> added, also added explicit return type
- removed logging since centralized in success() and error()
- refactored url into variable to make more uniform (some had it, some didnt)

### 5. implement in codebase

- use getDataOrThrow() everywhere, where we just need data
- moved status code checks from catch block into try block (AuthManager, ProfileView, RegisterView)