### PR TITLE
118 deny change of email password for google users

### DIFF
--- a/app/backend/src/controllers/users.controllers.js
+++ b/app/backend/src/controllers/users.controllers.js
@@ -8,7 +8,8 @@ import {
   createUserAvatar,
   deleteUserAvatar,
   getUserByUsername,
-  getUserByEmail
+  getUserByEmail,
+  getUserAuthProvider
 } from "../services/users.services.js";
 import { getUserStats } from "../services/user_stats.services.js";
 import {
@@ -400,6 +401,17 @@ export async function updateUserPasswordHandler(request, reply) {
   const action = "Update user password";
   try {
     const userId = parseInt(request.user.id, 10);
+    console.log(getUserAuthProvider(userId));
+
+    if (getUserAuthProvider(userId) !== "LOCAL") {
+      return httpError(
+        reply,
+        403,
+        createResponseMessage(action, false),
+        "User uses Google auth provider"
+      );
+    }
+
     const { currentPassword, newPassword } = request.body;
 
     const hashedPassword = await getPasswordHash(userId);

--- a/app/backend/src/controllers/users.controllers.js
+++ b/app/backend/src/controllers/users.controllers.js
@@ -418,7 +418,7 @@ export async function updateUserPasswordHandler(request, reply) {
         reply,
         403,
         createResponseMessage(action, false),
-        "User uses Google auth provider"
+        "Password can not be changed. User uses Google auth provider"
       );
     }
 

--- a/app/backend/src/controllers/users.controllers.js
+++ b/app/backend/src/controllers/users.controllers.js
@@ -116,6 +116,16 @@ export async function patchUserHandler(request, reply) {
   const action = "Patch user";
   try {
     const id = parseInt(request.user.id, 10);
+
+    if (request.body.email && getUserAuthProvider(id) !== "LOCAL") {
+      return httpError(
+        reply,
+        403,
+        createResponseMessage(action, false),
+        "Email can not be changed. User uses Google auth provider"
+      );
+    }
+
     const data = await updateUser(id, request.body);
     return reply
       .code(200)

--- a/app/backend/src/schema/common.schema.js
+++ b/app/backend/src/schema/common.schema.js
@@ -37,6 +37,11 @@ const commonDefinitionsSchema = {
         { $ref: "commonDefinitionsSchema#/definitions/email" }
       ]
     },
+    authProvider: {
+      type: "string",
+      enum: ["LOCAL", "GOOGLE"],
+      description: "Authentication provide which can be either LOCAL or GOOGLE"
+    },
     score: {
       type: "integer",
       minimum: 0,

--- a/app/backend/src/schema/users.schema.js
+++ b/app/backend/src/schema/users.schema.js
@@ -6,7 +6,12 @@ const userSchema = {
     username: { $ref: "commonDefinitionsSchema#/definitions/username" },
     email: { $ref: "commonDefinitionsSchema#/definitions/email" },
     avatar: { type: "string" },
-    dateJoined: { $ref: "commonDefinitionsSchema#/definitions/date" }
+    dateJoined: { $ref: "commonDefinitionsSchema#/definitions/date" },
+    authentication: {
+      authProvider: {
+        $ref: "commonDefinitionsSchema#/definitions/authProvider"
+      }
+    }
   },
   required: ["id", "username"],
   additionalProperties: false

--- a/app/backend/src/services/users.services.js
+++ b/app/backend/src/services/users.services.js
@@ -15,7 +15,12 @@ const userSelect = {
   username: true,
   email: true,
   avatar: true,
-  dateJoined: true
+  dateJoined: true,
+  authentication: {
+    select: {
+      authProvider: true
+    }
+  }
 };
 
 export async function createUser(
@@ -158,7 +163,7 @@ export async function getUserByUsername(username) {
 export async function getUserByEmail(email) {
   const user = await prisma.user.findUnique({
     where: { email },
-    select: { id: true, username: true , email: true, dateJoined: true }
+    select: { id: true, username: true, email: true, dateJoined: true }
   });
   return user;
 }

--- a/app/frontend/src/components/TextBox.ts
+++ b/app/frontend/src/components/TextBox.ts
@@ -1,0 +1,36 @@
+export type TextBoxOptions = {
+  id?: string;
+  text: string;
+  variant?: "info" | "warning" | "error";
+  size?: "sm" | "md" | "lg";
+  className?: string;
+};
+
+const textBoxVariants: Record<string, string> = {
+  info: "border border-neon-cyan text-neon-cyan shadow-neon-cyan",
+  warning: "border border-neon-yellow text-neon-yellow shadow-neon-yellow",
+  error: "border border-neon-red text-neon-red shadow-neon-red"
+};
+
+const textBoxSizes: Record<string, string> = {
+  sm: "px-3 py-3 text-sm",
+  md: "px-4 py-4 text-base",
+  lg: "px-6 py-6 text-lg"
+};
+
+export function TextBox({
+  id,
+  text,
+  variant = "info",
+  size = "md",
+  className = ""
+}: TextBoxOptions): string {
+  const classes = [
+    "flex items-center justify-center rounded-md font-bold uppercase whitespace-pre-line leading-relaxed",
+    textBoxVariants[variant],
+    textBoxSizes[size],
+    className
+  ].join(" ");
+  const idAttr = id ? ` id="${id}"` : "";
+  return `<div${idAttr} class="${classes}">${text}</div>`;
+}

--- a/app/frontend/src/services/userServices.ts
+++ b/app/frontend/src/services/userServices.ts
@@ -84,9 +84,7 @@ export async function getUserByUsername(
   return apiResponse.data;
 }
 
-export async function getUserByEmail(
-  email: string
-): Promise<User | null> {
+export async function getUserByEmail(email: string): Promise<User | null> {
   const apiResponse = await apiFetch<User | null>(
     `/api/users/search?email=${encodeURIComponent(email)}`,
     {
@@ -114,7 +112,10 @@ export async function getUserPlayedMatchesByUsername(
   return apiResponse.data;
 }
 
-export async function updateUserPassword(currentPassword: string, newPassword: string): Promise<void> {
+export async function updateUserPassword(
+  currentPassword: string,
+  newPassword: string
+): Promise<void> {
   const apiResponse = await apiFetch<User>("/api/users/me/password", {
     method: "PATCH",
     body: JSON.stringify({ currentPassword, newPassword }),

--- a/app/frontend/src/types/User.ts
+++ b/app/frontend/src/types/User.ts
@@ -4,4 +4,7 @@ export type User = {
   email?: string;
   avatar?: string;
   dateJoined: string;
+  authentication: {
+    authProvider: string;
+  };
 };

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -77,6 +77,17 @@ export default class ProfileView extends AbstractView {
     })}`;
   }
 
+  private getEmailInput(user: User): string {
+    return Input({
+      id: "email-input",
+      label: "Email",
+      name: "email",
+      type: "email",
+      placeholder: `${escapeHTML(user.email)}`,
+      errorId: "email-error"
+    });
+  }
+
   createHTML(): string {
     const user = auth.getUser();
 
@@ -138,14 +149,9 @@ export default class ProfileView extends AbstractView {
                   placeholder: `${escapeHTML(user.username)}`,
                   errorId: "username-error"
                 }),
-                Input({
-                  id: "email-input",
-                  label: "Email",
-                  name: "email",
-                  type: "email",
-                  placeholder: `${escapeHTML(user.email)}`,
-                  errorId: "email-error"
-                }),
+                auth.getUser().authentication.authProvider === "LOCAL"
+                  ? this.getEmailInput(user)
+                  : "",
                 Button({
                   text: "Save Changes",
                   variant: "default",

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -22,7 +22,7 @@ import { patchUser, updateUserPassword } from "../services/userServices.js";
 import { User } from "../types/User.js";
 import { toaster } from "../Toaster.js";
 import { ApiError } from "../services/api.js";
-import { layout } from "../Layout.js";
+import { TextBox } from "../components/TextBox.js";
 
 export default class ProfileView extends AbstractView {
   private avatarFormEl!: HTMLFormElement;
@@ -164,7 +164,13 @@ export default class ProfileView extends AbstractView {
             })}
             ${auth.getUser().authentication.authProvider === "LOCAL"
               ? this.getPasswordFormHTML()
-              : ""}
+              : TextBox({
+                  text: "Signed in with Google:\n\nYou cannot change your password or email address.\n\nPlease update your Google account settings instead.",
+                  variant: "warning",
+                  size: "lg",
+                  id: "random-text",
+                  className: "text-center"
+                })}
           </div>
         </div>
       </div>
@@ -285,7 +291,7 @@ export default class ProfileView extends AbstractView {
       const { avatar } = await uploadAvatar(formData);
       toaster.success("Avatar uploaded successfully!");
       const updatedUser: Partial<User> = {
-        ...(avatar ? { avatar } : {}),
+        ...(avatar ? { avatar } : {})
       };
       auth.updateUser(updatedUser);
       router.reload();

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -33,6 +33,50 @@ export default class ProfileView extends AbstractView {
     this.setTitle("Your Profile");
   }
 
+  private getPasswordFormHTML(): string {
+    return /* HTML */ ` ${Form({
+      id: "password-form",
+      className: "flex flex-col gap-4",
+      children: [
+        Paragraph({ text: "Change your password below." }),
+        Input({
+          id: "current-password-input",
+          label: "Current Password",
+          name: "currentPassword",
+          placeholder: "Current Password",
+          type: "password",
+          errorId: "current-password-error",
+          hasToggle: true
+        }),
+        Input({
+          id: "new-password-input",
+          label: "New Password",
+          name: "newPassword",
+          placeholder: "New Password",
+          type: "password",
+          errorId: "new-password-error",
+          hasToggle: true
+        }),
+        Input({
+          id: "confirm-new-password-input",
+          label: "Confirm New Password",
+          name: "confirmNewPassword",
+          placeholder: "Confirm New Password",
+          type: "password",
+          errorId: "confirm-error",
+          hasToggle: true
+        }),
+        Button({
+          text: "Change Password",
+          variant: "default",
+          size: "md",
+          type: "submit",
+          className: "mt-4 self-start"
+        })
+      ]
+    })}`;
+  }
+
   createHTML(): string {
     const user = auth.getUser();
 
@@ -111,47 +155,9 @@ export default class ProfileView extends AbstractView {
                 })
               ]
             })}
-            ${Form({
-              id: "password-form",
-              className: "flex flex-col gap-4",
-              children: [
-                Paragraph({ text: "Change your password below." }),
-                Input({
-                  id: "current-password-input",
-                  label: "Current Password",
-                  name: "currentPassword",
-                  placeholder: "Current Password",
-                  type: "password",
-                  errorId: "current-password-error",
-                  hasToggle: true
-                }),
-                Input({
-                  id: "new-password-input",
-                  label: "New Password",
-                  name: "newPassword",
-                  placeholder: "New Password",
-                  type: "password",
-                  errorId: "new-password-error",
-                  hasToggle: true
-                }),
-                Input({
-                  id: "confirm-new-password-input",
-                  label: "Confirm New Password",
-                  name: "confirmNewPassword",
-                  placeholder: "Confirm New Password",
-                  type: "password",
-                  errorId: "confirm-error",
-                  hasToggle: true
-                }),
-                Button({
-                  text: "Change Password",
-                  variant: "default",
-                  size: "md",
-                  type: "submit",
-                  className: "mt-4 self-start"
-                })
-              ]
-            })}
+            ${auth.getUser().authentication.authProvider === "LOCAL"
+              ? this.getPasswordFormHTML()
+              : ""}
           </div>
         </div>
       </div>
@@ -167,13 +173,15 @@ export default class ProfileView extends AbstractView {
       this.uploadAvatar(event)
     );
 
-    this.passwordFormEl.addEventListener("submit", (event) =>
-      this.handlePasswordChange(event)
-    );
+    if (auth.getUser().authentication.authProvider === "LOCAL") {
+      this.passwordFormEl.addEventListener("submit", (event) =>
+        this.handlePasswordChange(event)
+      );
 
-    addTogglePasswordListener("current-password-input");
-    addTogglePasswordListener("new-password-input");
-    addTogglePasswordListener("confirm-new-password-input");
+      addTogglePasswordListener("current-password-input");
+      addTogglePasswordListener("new-password-input");
+      addTogglePasswordListener("confirm-new-password-input");
+    }
   }
 
   async render(): Promise<void> {
@@ -194,8 +202,8 @@ export default class ProfileView extends AbstractView {
     let valid = true;
     const username = usernameEl.value;
     const email = emailEL.value;
-    const hasUsername = !isEmptyString(username)
-    const hasEmail = !isEmptyString(email)
+    const hasUsername = !isEmptyString(username);
+    const hasEmail = !isEmptyString(email);
 
     clearInvalid(usernameEl, usernameErrorEl);
     clearInvalid(emailEL, emailErrorEl);


### PR DESCRIPTION
# Overview

See #118 for more details. 

The following changes only apply to users, which used Google auth for registration:

- Options for changing email and password are not displayed in the fronted anymore
- A textbox indicates, that email and password can not be changed because of Google auth
- Handlers for updating password and email contain now check if user used the local auth or Google auth

## 1. 

Two functions, for the following purposes, were created:

1. Getting the password form
2. Getting the email input

If a user with Google auth user access his profile view, those functions do not get called and therefore the mentioned options do not get displayed. 

## 2. 

A new component was added - ``TextBox``:

- The design is based on the toasters
- It can be used for displaying an info, a warning or an error
- Can handle ``\n`` for line breaks

In this case, it displays a warning with the following text:
> Signed in with Google:
>
> You cannot change your password or email address.
> 
> Please update your Google account settings instead.

## 3. 

The following handlers include now a check, if the user has a local auth or google auth provider:

- ``updateUserPasswordHandler``
- ``patchUserHandler``

Therefore a user having Google as auth provider, can not even update his password and also not his email when he calls the corresponding routes which the correct body. 

 

