### PR TITLE
Check if hash is null

### DIFF
--- a/app/backend/src/services/auth.services.js
+++ b/app/backend/src/services/auth.services.js
@@ -19,6 +19,7 @@ export async function createHash(value) {
 }
 
 export async function verifyHash(hash, value) {
+  if (hash === null) return false;
   return await pkg.verify(hash, value);
 }
 


### PR DESCRIPTION
Bug description in #126 

``verifyHash`` checks now also, if the hash value is ``null``.
When this is the case, the function returns false. 

This results in an 401 error code, with the message "Invalid refresh token".