### PR TITLE
127 refreshing token clears layout

### DIFF
--- a/app/frontend/src/AuthManager.ts
+++ b/app/frontend/src/AuthManager.ts
@@ -45,9 +45,9 @@ export class AuthManager {
 
   private async updateAuthState(token: Token | null): Promise<void> {
     this.token = token;
-    if (token) {
+    if (this.token) {
       this.authenticated = true;
-      this.scheduleTokenValidation(token);
+      this.scheduleTokenValidation();
       this.registerActivityListeners();
       openSSEConnection();
     } else {
@@ -247,10 +247,10 @@ export class AuthManager {
     window.removeEventListener("keydown", this.startInactivityTimer);
   }
 
-  private scheduleTokenValidation(token: Token): void {
-    if (!token.exp) return;
+  private scheduleTokenValidation(): void {
+    if (!this.token!.exp) return;
 
-    const expiresAtMs = token.exp * 1000;
+    const expiresAtMs = this.token!.exp * 1000;
     const now = Date.now();
     const refreshAtMs = expiresAtMs - 60_000;
     const delay = Math.max(refreshAtMs - now, 1000);
@@ -275,9 +275,8 @@ export class AuthManager {
           throw new ApiError(apiResponse);
         }
       }
-      const newToken = getDataOrThrow(await authAndDecodeAccessToken());
-      this.token = newToken;
-      this.scheduleTokenValidation(newToken);
+      this.token = getDataOrThrow(await authAndDecodeAccessToken());
+      this.scheduleTokenValidation();
     } catch (error) {
       console.warn("Token refresh failed", error);
       this.clearTokenOnError();

--- a/app/frontend/src/AuthManager.ts
+++ b/app/frontend/src/AuthManager.ts
@@ -276,7 +276,8 @@ export class AuthManager {
         }
       }
       const newToken = getDataOrThrow(await authAndDecodeAccessToken());
-      this.updateAuthState(newToken);
+      this.token = newToken;
+      this.scheduleTokenValidation(newToken);
     } catch (error) {
       console.warn("Token refresh failed", error);
       this.clearTokenOnError();


### PR DESCRIPTION
For details see #127 

## Fix

In ``refreshToken``: 

- Directly set ``this.token`` with return value from ``authAndDecodeAccessToken``
- Call solely ``scheduleTokenValidation`` instead of ``updateAuthState``

## Refactor

Remove ``token`` argument from:

- ``updateAuthState``
- ``scheduleTokenValidation``

Use member var ``token`` instead