### PR TITLE
150 add generic element selector

### DIFF
--- a/app/frontend/src/Drawer.ts
+++ b/app/frontend/src/Drawer.ts
@@ -3,6 +3,7 @@ import { Sidebar } from "./components/Sidebar.js";
 import { Overlay } from "./components/Overlay.js";
 import { sanitizeHTML } from "./sanitize.js";
 import { router } from "./routing/Router.js";
+import { getById } from "./utility.js";
 
 export type DrawerItem = {
   label: string;
@@ -111,8 +112,8 @@ export class Drawer {
         });
       });
 
-    const closeBtn = this.drawerEl.querySelector("#drawer-close");
-    closeBtn?.addEventListener("click", () => this.close());
+    const closeBtn = getById<HTMLButtonElement>("drawer-close");
+    closeBtn.addEventListener("click", () => this.close());
 
     this.overlayEl.addEventListener("click", () => this.close());
   }

--- a/app/frontend/src/Layout.ts
+++ b/app/frontend/src/Layout.ts
@@ -16,7 +16,7 @@ export class Layout {
   private languageSwitcherOptionsEl!: HTMLDivElement;
 
   constructor() {
-    this.rootEl = getById<HTMLDivElement>("app");
+    this.rootEl = getById("app");
     this.styleRootElement();
   }
 
@@ -45,10 +45,8 @@ export class Layout {
     this.rootEl.innerHTML = cleanHTML;
 
     this.attachAvatarDrawerHandler();
-    this.languageSwitcherButtonEl = getById<HTMLButtonElement>(
-      "lang-switcher-button"
-    )!;
-    this.languageSwitcherOptionsEl = getById("lang-switcher-options")!;
+    this.languageSwitcherButtonEl = getById("lang-switcher-button");
+    this.languageSwitcherOptionsEl = getById("lang-switcher-options");
     this.attachLanguageSwitcherHandler();
   }
 

--- a/app/frontend/src/Layout.ts
+++ b/app/frontend/src/Layout.ts
@@ -4,7 +4,7 @@ import { Link } from "./components/Link.js";
 import { Drawer } from "./Drawer.js";
 import { LanguageSwitcher } from "./components/LanguageSwitcher.js";
 import { Language } from "./types/User.js";
-import { getById, getEl } from "./utility.js";
+import { getById } from "./utility.js";
 
 export type LayoutMode = "auth" | "guest";
 
@@ -48,7 +48,7 @@ export class Layout {
     this.languageSwitcherButtonEl = getById<HTMLButtonElement>(
       "lang-switcher-button"
     )!;
-    this.languageSwitcherOptionsEl = getEl("lang-switcher-options")!;
+    this.languageSwitcherOptionsEl = getById("lang-switcher-options")!;
     this.attachLanguageSwitcherHandler();
   }
 

--- a/app/frontend/src/Layout.ts
+++ b/app/frontend/src/Layout.ts
@@ -4,7 +4,7 @@ import { Link } from "./components/Link.js";
 import { Drawer } from "./Drawer.js";
 import { LanguageSwitcher } from "./components/LanguageSwitcher.js";
 import { Language } from "./types/User.js";
-import { getById } from "./utility.js";
+import { getAllBySelector, getById } from "./utility.js";
 
 export type LayoutMode = "auth" | "guest";
 
@@ -181,15 +181,15 @@ export class Layout {
       this.languageSwitcherOptionsEl.classList.toggle("hidden");
     });
 
-    this.languageSwitcherOptionsEl
-      .querySelectorAll("button[data-lang]")
-      .forEach((btn) => {
-        btn.addEventListener("click", async (e) => {
-          const lang = (e.currentTarget as HTMLElement).dataset
-            .lang as Language;
-          await auth.updateLanguage(lang);
-        });
+    const buttons = getAllBySelector<HTMLButtonElement>("button[data-lang]", {
+      root: this.languageSwitcherOptionsEl
+    });
+    buttons.forEach((btn) => {
+      btn.addEventListener("click", async (e) => {
+        const lang = (e.currentTarget as HTMLElement).dataset.lang as Language;
+        await auth.updateLanguage(lang);
       });
+    });
 
     document.addEventListener("click", this.onDocumentClick);
   }

--- a/app/frontend/src/Layout.ts
+++ b/app/frontend/src/Layout.ts
@@ -4,7 +4,7 @@ import { Link } from "./components/Link.js";
 import { Drawer } from "./Drawer.js";
 import { LanguageSwitcher } from "./components/LanguageSwitcher.js";
 import { Language } from "./types/User.js";
-import { getButtonEl, getEl } from "./utility.js";
+import { getById, getEl } from "./utility.js";
 
 export type LayoutMode = "auth" | "guest";
 
@@ -45,7 +45,9 @@ export class Layout {
     this.rootEl.innerHTML = cleanHTML;
 
     this.attachAvatarDrawerHandler();
-    this.languageSwitcherButtonEl = getButtonEl("lang-switcher-button")!;
+    this.languageSwitcherButtonEl = getById<HTMLButtonElement>(
+      "lang-switcher-button"
+    )!;
     this.languageSwitcherOptionsEl = getEl("lang-switcher-options")!;
     this.attachLanguageSwitcherHandler();
   }

--- a/app/frontend/src/Layout.ts
+++ b/app/frontend/src/Layout.ts
@@ -11,12 +11,12 @@ export type LayoutMode = "auth" | "guest";
 export class Layout {
   private static instance: Layout;
   private mode: LayoutMode = "guest";
-  private rootEl: HTMLElement;
-  private languageSwitcherButtonEl!: HTMLElement;
-  private languageSwitcherOptionsEl!: HTMLElement;
+  private rootEl: HTMLDivElement;
+  private languageSwitcherButtonEl!: HTMLButtonElement;
+  private languageSwitcherOptionsEl!: HTMLDivElement;
 
   constructor() {
-    this.rootEl = document.getElementById("app")!;
+    this.rootEl = getById<HTMLDivElement>("app");
     this.styleRootElement();
   }
 

--- a/app/frontend/src/Toaster.ts
+++ b/app/frontend/src/Toaster.ts
@@ -1,4 +1,5 @@
 import { Toast, ToastVariant } from "./components/Toast.js";
+import { getBySelector } from "./utility.js";
 
 interface ToastData {
   timeoutId: number;
@@ -44,10 +45,8 @@ export class Toaster {
     template.innerHTML = html.trim();
     const toast = template.content.firstElementChild as HTMLElement;
 
-    // Click close button
-    toast
-      .querySelector("button")!
-      .addEventListener("click", () => this.removeToast(toast));
+    const closeBtn = getBySelector("button", toast);
+    closeBtn.addEventListener("click", () => this.removeToast(toast));
 
     // Hover handlers: pause/resume
     toast.addEventListener("mouseenter", () => this.pauseToast(toast));

--- a/app/frontend/src/Toaster.ts
+++ b/app/frontend/src/Toaster.ts
@@ -45,7 +45,7 @@ export class Toaster {
     template.innerHTML = html.trim();
     const toast = template.content.firstElementChild as HTMLElement;
 
-    const closeBtn = getBySelector("button", toast);
+    const closeBtn = getBySelector<HTMLButtonElement>("button", toast);
     closeBtn.addEventListener("click", () => this.removeToast(toast));
 
     // Hover handlers: pause/resume

--- a/app/frontend/src/charts/chartUtils.ts
+++ b/app/frontend/src/charts/chartUtils.ts
@@ -1,12 +1,12 @@
 import type { ApexOptions } from "apexcharts";
-import { getEl } from "../utility.js";
+import { getById } from "../utility.js";
 import { TournamentSize } from "../types/ITournament.js";
 
 export async function renderChart(
   id: string,
   options: ApexOptions
 ): Promise<ApexCharts> {
-  const chartEl = getEl(id);
+  const chartEl = getById<HTMLDivElement>(id);
 
   const chart = new ApexCharts(chartEl, options);
   await chart.render();

--- a/app/frontend/src/components/Input.ts
+++ b/app/frontend/src/components/Input.ts
@@ -1,4 +1,4 @@
-import { getButtonEl, getById, getEl } from "../utility.js";
+import { getById, getEl } from "../utility.js";
 import { Span } from "./Span.js";
 
 export type InputOptions = {
@@ -196,7 +196,7 @@ export function addTogglePasswordListener(id: string) {
   const passwordEl = getById<HTMLInputElement>(id);
   const showEyeEl = getEl(`${id}-show-eye`);
   const hideEyeEl = getEl(`${id}-hide-eye`);
-  const buttonEl = getButtonEl(`${id}-toggle`);
+  const buttonEl = getById<HTMLButtonElement>(`${id}-toggle`);
 
   buttonEl.addEventListener("click", () =>
     togglePasswordVisibility(passwordEl, showEyeEl, hideEyeEl)

--- a/app/frontend/src/components/Input.ts
+++ b/app/frontend/src/components/Input.ts
@@ -1,4 +1,4 @@
-import { getById, getEl } from "../utility.js";
+import { getById } from "../utility.js";
 import { Span } from "./Span.js";
 
 export type InputOptions = {
@@ -194,8 +194,8 @@ function togglePasswordVisibility(
 
 export function addTogglePasswordListener(id: string) {
   const passwordEl = getById<HTMLInputElement>(id);
-  const showEyeEl = getEl(`${id}-show-eye`);
-  const hideEyeEl = getEl(`${id}-hide-eye`);
+  const showEyeEl = getById<HTMLSpanElement>(`${id}-show-eye`);
+  const hideEyeEl = getById<HTMLSpanElement>(`${id}-hide-eye`);
   const buttonEl = getById<HTMLButtonElement>(`${id}-toggle`);
 
   buttonEl.addEventListener("click", () =>

--- a/app/frontend/src/components/Input.ts
+++ b/app/frontend/src/components/Input.ts
@@ -183,8 +183,8 @@ function getEyeIconHTML(type: "show" | "hide"): string {
 
 function togglePasswordVisibility(
   passwordEl: HTMLInputElement,
-  showEyeEl: HTMLElement,
-  hideEyeEl: HTMLElement
+  showEyeEl: HTMLSpanElement,
+  hideEyeEl: HTMLSpanElement
 ): void {
   const isHidden = passwordEl.type === "password";
   passwordEl.type = isHidden ? "text" : "password";

--- a/app/frontend/src/components/Input.ts
+++ b/app/frontend/src/components/Input.ts
@@ -1,4 +1,4 @@
-import { getButtonEl, getEl, getInputEl } from "../utility.js";
+import { getButtonEl, getById, getEl } from "../utility.js";
 import { Span } from "./Span.js";
 
 export type InputOptions = {
@@ -193,7 +193,7 @@ function togglePasswordVisibility(
 }
 
 export function addTogglePasswordListener(id: string) {
-  const passwordEl = getInputEl(id);
+  const passwordEl = getById<HTMLInputElement>(id);
   const showEyeEl = getEl(`${id}-show-eye`);
   const hideEyeEl = getEl(`${id}-hide-eye`);
   const buttonEl = getButtonEl(`${id}-toggle`);

--- a/app/frontend/src/components/Modal.ts
+++ b/app/frontend/src/components/Modal.ts
@@ -1,4 +1,4 @@
-import { getById, getEl } from "../utility.js";
+import { getById } from "../utility.js";
 import { Button } from "./Button.js";
 
 export type ModalOptions = {
@@ -40,7 +40,7 @@ export function Modal({
 }
 
 export function addCloseModalListener(id: string) {
-  const modalEl = getEl(id) as HTMLDialogElement;
+  const modalEl = getById<HTMLDialogElement>(id);
   const modalCloseButtonEl = getById<HTMLButtonElement>(`${id}-close-button`);
 
   modalEl.addEventListener("click", (e) => {

--- a/app/frontend/src/components/Modal.ts
+++ b/app/frontend/src/components/Modal.ts
@@ -1,4 +1,4 @@
-import { getButtonEl, getEl } from "../utility.js";
+import { getById, getEl } from "../utility.js";
 import { Button } from "./Button.js";
 
 export type ModalOptions = {
@@ -41,7 +41,7 @@ export function Modal({
 
 export function addCloseModalListener(id: string) {
   const modalEl = getEl(id) as HTMLDialogElement;
-  const modalCloseButtonEl = getButtonEl(`${id}-close-button`);
+  const modalCloseButtonEl = getById<HTMLButtonElement>(`${id}-close-button`);
 
   modalEl.addEventListener("click", (e) => {
     const dialogDimensions = modalEl.getBoundingClientRect();

--- a/app/frontend/src/components/NicknameInput.ts
+++ b/app/frontend/src/components/NicknameInput.ts
@@ -1,3 +1,4 @@
+import { getAllBySelector } from "../utility.js";
 import { Checkbox } from "./Checkbox.js";
 import { Input } from "./Input.js";
 import { Radio } from "./Radio.js";
@@ -39,10 +40,8 @@ export function NicknameInput(players: number): string {
 }
 
 export function initNicknameInputListeners(): void {
-  const radios = document.querySelectorAll<HTMLInputElement>(
-    'input[name="userChoice"]'
-  );
-  const checkboxes = document.querySelectorAll<HTMLInputElement>(
+  const radios = getAllBySelector<HTMLInputElement>('input[name="userChoice"]');
+  const checkboxes = getAllBySelector<HTMLInputElement>(
     'input[type="checkbox"][id^="ai-"]'
   );
 

--- a/app/frontend/src/game.ts
+++ b/app/frontend/src/game.ts
@@ -8,6 +8,7 @@ import { createMatch } from "./services/matchServices.js";
 import { playedAs, PlayerType } from "./types/IMatch.js";
 import { getDataOrThrow } from "./services/api.js";
 import { AIPlayer } from "./AIPlayer.js";
+import { getById } from "./utility.js";
 
 let isAborted: boolean = false;
 
@@ -28,7 +29,7 @@ export async function startGame(
   tournament: Tournament | null,
   keys: Record<GameKey, boolean>
 ) {
-  const canvas = document.getElementById("gameCanvas") as HTMLCanvasElement;
+  const canvas = getById<HTMLCanvasElement>("gameCanvas");
   const ctx = canvas.getContext("2d")!;
 
   setIsAborted(false);

--- a/app/frontend/src/routing/routeChangeListener.ts
+++ b/app/frontend/src/routing/routeChangeListener.ts
@@ -1,4 +1,5 @@
 import { RouteChangeListener } from "../types/Route";
+import { getAllBySelector } from "../utility.js";
 
 export const logRouteChange: RouteChangeListener = (info) => {
   if (info.event === "nav") {
@@ -12,7 +13,7 @@ export const logRouteChange: RouteChangeListener = (info) => {
 };
 
 export const updateUI: RouteChangeListener = (info) => {
-  const navItems = document.querySelectorAll("[data-link]");
+  const navItems = getAllBySelector<HTMLAnchorElement>("[data-link]");
   navItems.forEach((item) => {
     const href = item.getAttribute("href");
     if (href === info.to) {

--- a/app/frontend/src/utility.ts
+++ b/app/frontend/src/utility.ts
@@ -8,10 +8,6 @@ export function escapeHTML(input: string | undefined | null): string {
     .replace(/'/g, "&#039;");
 }
 
-export function getEl(elId: string): HTMLElement {
-  return document.getElementById(elId) as HTMLElement;
-}
-
 export function getCookieValueByName(cookieName: string): string {
   const match = document.cookie.match(
     new RegExp("(^|; )" + cookieName + "=([^;]+)")

--- a/app/frontend/src/utility.ts
+++ b/app/frontend/src/utility.ts
@@ -39,6 +39,10 @@ export function getBySelector<T extends HTMLElement>(
   return el;
 }
 
+export function getById<T extends HTMLElement>(id: string): T {
+  return getBySelector<T>(`#${id}`);
+}
+
 export function getAllBySelector<T extends HTMLElement>(
   selector: string,
   root: ParentNode = document,

--- a/app/frontend/src/utility.ts
+++ b/app/frontend/src/utility.ts
@@ -26,3 +26,15 @@ export function getCookieValueByName(cookieName: string): string {
   );
   return match ? match[2] : "";
 }
+
+export function getBySelector<T extends HTMLElement>(
+  selector: string,
+  root: ParentNode = document
+): T {
+  const el = root.querySelector<T>(selector);
+  if (!el) {
+    console.error(`Element "${selector}" not found`);
+    throw new Error(i18next.t("error.unexpected"));
+  }
+  return el;
+}

--- a/app/frontend/src/utility.ts
+++ b/app/frontend/src/utility.ts
@@ -8,10 +8,6 @@ export function escapeHTML(input: string | undefined | null): string {
     .replace(/'/g, "&#039;");
 }
 
-export function getInputEl(inputId: string): HTMLInputElement {
-  return document.getElementById(inputId) as HTMLInputElement;
-}
-
 export function getEl(elId: string): HTMLElement {
   return document.getElementById(elId) as HTMLElement;
 }

--- a/app/frontend/src/utility.ts
+++ b/app/frontend/src/utility.ts
@@ -33,8 +33,10 @@ export function getById<T extends HTMLElement>(id: string): T {
 
 export function getAllBySelector<T extends HTMLElement>(
   selector: string,
-  root: ParentNode = document,
-  { strict = true } = {}
+  {
+    root = document,
+    strict = true
+  }: { root?: ParentNode; strict?: boolean } = {}
 ): T[] {
   const elements = root.querySelectorAll<T>(selector);
   if (elements.length === 0 && strict) {

--- a/app/frontend/src/utility.ts
+++ b/app/frontend/src/utility.ts
@@ -12,10 +12,6 @@ export function getEl(elId: string): HTMLElement {
   return document.getElementById(elId) as HTMLElement;
 }
 
-export function getButtonEl(buttonId: string): HTMLButtonElement {
-  return document.getElementById(buttonId) as HTMLButtonElement;
-}
-
 export function getCookieValueByName(cookieName: string): string {
   const match = document.cookie.match(
     new RegExp("(^|; )" + cookieName + "=([^;]+)")

--- a/app/frontend/src/utility.ts
+++ b/app/frontend/src/utility.ts
@@ -38,3 +38,16 @@ export function getBySelector<T extends HTMLElement>(
   }
   return el;
 }
+
+export function getAllBySelector<T extends HTMLElement>(
+  selector: string,
+  root: ParentNode = document,
+  { strict = true } = {}
+): T[] {
+  const elements = root.querySelectorAll<T>(selector);
+  if (elements.length === 0 && strict) {
+    console.error(`No elements match selector "${selector}"`);
+    throw new Error(i18next.t("error.unexpected"));
+  }
+  return Array.from(elements);
+}

--- a/app/frontend/src/validate.ts
+++ b/app/frontend/src/validate.ts
@@ -13,7 +13,7 @@ function validateAgainstRegex(str: string, regex: RegExp): boolean {
 export function markInvalid(
   message: string,
   inputEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): void {
   inputEl.focus();
   inputEl.classList.add(
@@ -29,7 +29,7 @@ export function markInvalid(
 
 export function clearInvalid(
   inputEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): void {
   inputEl.classList.remove(
     "border-2",
@@ -43,7 +43,7 @@ export function clearInvalid(
 
 export function validateNicknames(
   inputElements: HTMLInputElement[],
-  errorElements: HTMLElement[],
+  errorElements: HTMLSpanElement[],
   nicknames: string[]
 ): boolean {
   const nicknameRegex = /^[a-zA-Z0-9-!?_$.]{3,20}$/;
@@ -81,7 +81,7 @@ export function validateNicknames(
 
 export function validateTournamentName(
   inputEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): boolean {
   const tournamentNameRegex = /^[a-zA-Z0-9-!?_$.]{3,20}$/;
   const tournamentName: string = inputEl.value;
@@ -103,7 +103,7 @@ export function validateTournamentName(
 export async function isTournamentNameAvailable(
   username: string,
   inputEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): Promise<boolean> {
   try {
     const tournamentsPage = getDataOrThrow(
@@ -129,7 +129,7 @@ export async function isTournamentNameAvailable(
 export function validatePlayersSelection(
   playersSelected: HTMLInputElement,
   selectionEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): boolean {
   clearInvalid(selectionEl, errorEl);
 
@@ -142,7 +142,7 @@ export function validatePlayersSelection(
 
 export function validatePassword(
   inputEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): boolean {
   const passwordRegex: RegExp =
     /^(?=.*[a-z])(?=.*[A-Z])(?=.*[@$!%*?&])(?=.*[0-9])[A-Za-z0-9@$!%*?&]{10,64}$/;
@@ -165,7 +165,7 @@ export function validatePassword(
 export function validateConfirmPassword(
   inputElOne: HTMLInputElement,
   inputElTwo: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): boolean {
   if (isEmptyString(inputElTwo.value)) {
     markInvalid(
@@ -187,7 +187,7 @@ export function validateConfirmPassword(
 
 export function validateUsername(
   inputEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): boolean {
   const usernameRegex: RegExp = /^[a-zA-Z0-9-!?_$.]{3,20}$/;
   const username: string = inputEl.value;
@@ -208,7 +208,7 @@ export function validateUsername(
 
 export function validateEmail(
   inputEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): boolean {
   const emailRegex: RegExp = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
   const email: string = inputEl.value;
@@ -229,7 +229,7 @@ export function validateEmail(
 
 export function validateUsernameOrEmail(
   inputEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): boolean {
   clearInvalid(inputEl, errorEl);
   if (isEmptyString(inputEl.value)) {
@@ -246,7 +246,7 @@ export function validateUsernameOrEmail(
 
 export function validateImageFile(
   inputEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): boolean {
   clearInvalid(inputEl, errorEl);
 
@@ -265,7 +265,7 @@ export function validateImageFile(
 
 export async function validateTwoFACode(
   inputEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): Promise<boolean> {
   const twoFACodeRegex: RegExp = /^\d{6}$/;
   const twoFACode = inputEl.value;
@@ -285,7 +285,7 @@ export async function validateTwoFACode(
 
 export async function validatTwoFABackupCode(
   inputEl: HTMLInputElement,
-  errorEl: HTMLElement
+  errorEl: HTMLSpanElement
 ): Promise<boolean> {
   const twoFABackupCodeRegex: RegExp = /^\d{8}$/;
   const twoFABackupCode = inputEl.value;

--- a/app/frontend/src/views/AbstractView.ts
+++ b/app/frontend/src/views/AbstractView.ts
@@ -1,4 +1,5 @@
 import { sanitizeHTML } from "../sanitize.js";
+import { getById } from "../utility.js";
 
 export default abstract class AbstractView {
   constructor() {}
@@ -12,7 +13,8 @@ export default abstract class AbstractView {
   updateHTML(): void {
     const html = this.createHTML();
     const cleanHTML = sanitizeHTML(html);
-    document.querySelector("#app-content")!.innerHTML = cleanHTML;
+    const container = getById<HTMLDivElement>("app-content");
+    container.innerHTML = cleanHTML;
   }
 
   abstract render(): Promise<void>;

--- a/app/frontend/src/views/ErrorView.ts
+++ b/app/frontend/src/views/ErrorView.ts
@@ -4,6 +4,7 @@ import { router } from "../routing/Router.js";
 import { Header1 } from "../components/Header1.js";
 import { Paragraph } from "../components/Paragraph.js";
 import { Button } from "../components/Button.js";
+import { getById } from "../utility.js";
 
 export default class ErrorView extends AbstractView {
   private message: string = i18next.t("error.unexpected");
@@ -52,7 +53,8 @@ export default class ErrorView extends AbstractView {
   }
 
   protected addListeners(): void {
-    document.getElementById("reload-btn")!.addEventListener("click", () => {
+    const reloadBtn = getById<HTMLButtonElement>("reload-btn");
+    reloadBtn.addEventListener("click", () => {
       router.reload();
     });
   }

--- a/app/frontend/src/views/FriendsView.ts
+++ b/app/frontend/src/views/FriendsView.ts
@@ -346,7 +346,7 @@ export default class FriendsView extends AbstractView {
   private handleSendRequestButton = async (event: Event): Promise<void> => {
     event.preventDefault();
     const inputEl = getById<HTMLInputElement>("username-input");
-    const errorEl = getById("username-error");
+    const errorEl = getById<HTMLSpanElement>("username-error");
 
     clearInvalid(inputEl, errorEl);
 

--- a/app/frontend/src/views/FriendsView.ts
+++ b/app/frontend/src/views/FriendsView.ts
@@ -14,7 +14,7 @@ import {
   FriendRequestEvent,
   FriendStatusChangeEvent
 } from "../types/ServerSentEvents.js";
-import { escapeHTML, getEl, getInputEl } from "../utility.js";
+import { escapeHTML, getById, getEl } from "../utility.js";
 import { clearInvalid, markInvalid, validateUsername } from "../validate.js";
 import AbstractView from "./AbstractView.js";
 import { Button } from "../components/Button.js";
@@ -334,7 +334,7 @@ export default class FriendsView extends AbstractView {
 
   private handleSendRequestButton = async (event: Event): Promise<void> => {
     event.preventDefault();
-    const inputEl = getInputEl("username-input");
+    const inputEl = getById<HTMLInputElement>("username-input");
     const errorEl = getEl("username-error");
 
     clearInvalid(inputEl, errorEl);

--- a/app/frontend/src/views/FriendsView.ts
+++ b/app/frontend/src/views/FriendsView.ts
@@ -14,7 +14,7 @@ import {
   FriendRequestEvent,
   FriendStatusChangeEvent
 } from "../types/ServerSentEvents.js";
-import { escapeHTML, getById, getEl } from "../utility.js";
+import { escapeHTML, getById } from "../utility.js";
 import { clearInvalid, markInvalid, validateUsername } from "../validate.js";
 import AbstractView from "./AbstractView.js";
 import { Button } from "../components/Button.js";
@@ -68,7 +68,8 @@ export default class FriendsView extends AbstractView {
         );
     }
 
-    getEl(containerId).innerHTML = cleanHTML;
+    const container = getById<HTMLDivElement>(containerId);
+    container.innerHTML = cleanHTML;
     this.addRequestListListeners(type);
   }
 
@@ -197,7 +198,8 @@ export default class FriendsView extends AbstractView {
       }
     );
 
-    getEl("send-request-form").addEventListener(
+    const requestForm = getById<HTMLFormElement>("send-request-form");
+    requestForm.addEventListener(
       "submit",
       (event) => this.handleSendRequestButton(event),
       {
@@ -335,7 +337,7 @@ export default class FriendsView extends AbstractView {
   private handleSendRequestButton = async (event: Event): Promise<void> => {
     event.preventDefault();
     const inputEl = getById<HTMLInputElement>("username-input");
-    const errorEl = getEl("username-error");
+    const errorEl = getById("username-error");
 
     clearInvalid(inputEl, errorEl);
 

--- a/app/frontend/src/views/FriendsView.ts
+++ b/app/frontend/src/views/FriendsView.ts
@@ -14,7 +14,12 @@ import {
   FriendRequestEvent,
   FriendStatusChangeEvent
 } from "../types/ServerSentEvents.js";
-import { escapeHTML, getById } from "../utility.js";
+import {
+  escapeHTML,
+  getAllBySelector,
+  getById,
+  getBySelector
+} from "../utility.js";
 import { clearInvalid, markInvalid, validateUsername } from "../validate.js";
 import AbstractView from "./AbstractView.js";
 import { Button } from "../components/Button.js";
@@ -220,7 +225,8 @@ export default class FriendsView extends AbstractView {
     toastMessage: string,
     toastIcon?: string
   ): void => {
-    document.querySelectorAll(selector).forEach((btn) => {
+    const buttons = getAllBySelector(selector, { strict: false });
+    buttons.forEach((btn) => {
       btn.addEventListener(
         "click",
         async (event) => {
@@ -318,14 +324,17 @@ export default class FriendsView extends AbstractView {
   private handleFriendStatusChange = (event: Event) => {
     const customEvent = event as FriendStatusChangeEvent;
     const { requestId, isOnline } = customEvent.detail;
-    const container = document.querySelector<HTMLElement>(
+    const container = getBySelector<HTMLLIElement>(
       `li[data-request-id="${requestId}"]`
     );
     if (!container) {
       console.warn("Tried to update status, but container not found");
       return;
     }
-    const statusSpan = container.querySelector(".online-status")!;
+    const statusSpan = getBySelector<HTMLSpanElement>(
+      ".online-status",
+      container
+    );
 
     statusSpan.textContent = isOnline
       ? i18next.t("global.online")

--- a/app/frontend/src/views/FriendsView.ts
+++ b/app/frontend/src/views/FriendsView.ts
@@ -324,7 +324,7 @@ export default class FriendsView extends AbstractView {
   private handleFriendStatusChange = (event: Event) => {
     const customEvent = event as FriendStatusChangeEvent;
     const { requestId, isOnline } = customEvent.detail;
-    const container = getBySelector<HTMLLIElement>(
+    const container = document.querySelector<HTMLLIElement>(
       `li[data-request-id="${requestId}"]`
     );
     if (!container) {

--- a/app/frontend/src/views/LoginView.ts
+++ b/app/frontend/src/views/LoginView.ts
@@ -7,6 +7,7 @@ import { router } from "../routing/Router.js";
 import { addTogglePasswordListener, Input } from "../components/Input.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
+import { getById } from "../utility.js";
 
 export default class LoginView extends AbstractView {
   constructor() {
@@ -80,15 +81,11 @@ export default class LoginView extends AbstractView {
 
   private async validateAndLoginUser(event: Event) {
     event.preventDefault();
-    const userEl = document.getElementById(
-      "usernameOrEmail"
-    ) as HTMLInputElement;
-    const userErrorEl = document.getElementById(
-      "usernameOrEmail-error"
-    ) as HTMLElement;
-    const passwordEl = document.getElementById("password") as HTMLInputElement;
+    const userEl = getById<HTMLInputElement>("usernameOrEmail");
+    const userErrorEl = getById<HTMLElement>("usernameOrEmail-error");
+    const passwordEl = getById<HTMLInputElement>("password");
     // FIXME: activate when password policy is applied
-    // const passwordErrorEl = document.getElementById(
+    // const passwordErrorEl = getById<HTMLElement>(
     //   "password-error"
     // ) as HTMLElement;
 

--- a/app/frontend/src/views/NewGameView.ts
+++ b/app/frontend/src/views/NewGameView.ts
@@ -52,14 +52,13 @@ export default class NewGameView extends AbstractView {
 
   async render() {
     this.updateHTML();
-    this.formEl = getById<HTMLFormElement>("register-form");
+    this.formEl = getById("register-form");
     this.addListeners();
   }
 
   validateAndStartGame(event: Event) {
     event.preventDefault();
-    const form = getById<HTMLFormElement>("register-form");
-    const formData = new FormData(form);
+    const formData = new FormData(this.formEl);
     const inputElements = getAllBySelector<HTMLInputElement>(
       "input[type='text']",
       { root: this.formEl }

--- a/app/frontend/src/views/NewGameView.ts
+++ b/app/frontend/src/views/NewGameView.ts
@@ -8,7 +8,7 @@ import {
   NicknameInput
 } from "../components/NicknameInput.js";
 import { Paragraph } from "../components/Paragraph.js";
-import { escapeHTML } from "../utility.js";
+import { escapeHTML, getById } from "../utility.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
 import { playedAs } from "../types/IMatch.js";
@@ -52,13 +52,13 @@ export default class NewGameView extends AbstractView {
 
   async render() {
     this.updateHTML();
-    this.formEl = document.querySelector("#register-form")!;
+    this.formEl = getById<HTMLFormElement>("register-form");
     this.addListeners();
   }
 
   validateAndStartGame(event: Event) {
     event.preventDefault();
-    const form = document.getElementById("register-form") as HTMLFormElement;
+    const form = getById<HTMLFormElement>("register-form");
     const formData = new FormData(form);
     const inputElements: HTMLInputElement[] = Array.from(
       this.formEl.querySelectorAll("input[type='text']")

--- a/app/frontend/src/views/NewGameView.ts
+++ b/app/frontend/src/views/NewGameView.ts
@@ -8,7 +8,7 @@ import {
   NicknameInput
 } from "../components/NicknameInput.js";
 import { Paragraph } from "../components/Paragraph.js";
-import { escapeHTML, getById } from "../utility.js";
+import { escapeHTML, getAllBySelector, getById } from "../utility.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
 import { playedAs } from "../types/IMatch.js";
@@ -60,11 +60,13 @@ export default class NewGameView extends AbstractView {
     event.preventDefault();
     const form = getById<HTMLFormElement>("register-form");
     const formData = new FormData(form);
-    const inputElements: HTMLInputElement[] = Array.from(
-      this.formEl.querySelectorAll("input[type='text']")
+    const inputElements = getAllBySelector<HTMLInputElement>(
+      "input[type='text']",
+      { root: this.formEl }
     );
-    const errorElements: HTMLElement[] = Array.from(
-      this.formEl.querySelectorAll('[id^="player-error-"]')
+    const errorElements = getAllBySelector<HTMLElement>(
+      '[id^="player-error-"]',
+      { root: this.formEl }
     );
     const nicknames = inputElements.map((input) => input.value);
 

--- a/app/frontend/src/views/NewTournamentView.ts
+++ b/app/frontend/src/views/NewTournamentView.ts
@@ -19,7 +19,7 @@ import { RadioGroup } from "../components/RadioGroup.js";
 import { Form } from "../components/Form.js";
 import { getDataOrThrow } from "../services/api.js";
 import { auth } from "../AuthManager.js";
-import { getById } from "../utility.js";
+import { getById, getBySelector } from "../utility.js";
 
 export default class NewTournamentView extends AbstractView {
   private formEl!: HTMLFormElement;
@@ -129,9 +129,9 @@ export default class NewTournamentView extends AbstractView {
       'input[name="players"]:checked'
     ) as HTMLInputElement;
     const tournamentNameEl = getById<HTMLInputElement>("tournament-name-input");
-    const selectionEl = document.querySelector(
+    const selectionEl = getBySelector<HTMLInputElement>(
       'input[name="players"]'
-    ) as HTMLInputElement;
+    );
     const tournamentErrorEl = getById<HTMLElement>("tournament-name-error");
     const playerErrorEl = getById<HTMLElement>("player-error");
     let isValid = true;

--- a/app/frontend/src/views/NewTournamentView.ts
+++ b/app/frontend/src/views/NewTournamentView.ts
@@ -100,7 +100,7 @@ export default class NewTournamentView extends AbstractView {
     if (tournamentsPage.items.length === 0) {
       console.log("No active tournament found");
       this.updateHTML();
-      this.formEl = getById<HTMLFormElement>("tournament-form");
+      this.formEl = getById("tournament-form");
       this.addListeners();
       return;
     }

--- a/app/frontend/src/views/NewTournamentView.ts
+++ b/app/frontend/src/views/NewTournamentView.ts
@@ -19,6 +19,7 @@ import { RadioGroup } from "../components/RadioGroup.js";
 import { Form } from "../components/Form.js";
 import { getDataOrThrow } from "../services/api.js";
 import { auth } from "../AuthManager.js";
+import { getById } from "../utility.js";
 
 export default class NewTournamentView extends AbstractView {
   private formEl!: HTMLFormElement;
@@ -99,7 +100,7 @@ export default class NewTournamentView extends AbstractView {
     if (tournamentsPage.items.length === 0) {
       console.log("No active tournament found");
       this.updateHTML();
-      this.formEl = document.querySelector("#tournament-form")!;
+      this.formEl = getById<HTMLFormElement>("tournament-form");
       this.addListeners();
       return;
     }
@@ -127,18 +128,12 @@ export default class NewTournamentView extends AbstractView {
     const playersSelected = this.formEl.querySelector(
       'input[name="players"]:checked'
     ) as HTMLInputElement;
-    const tournamentNameEl = document.getElementById(
-      "tournament-name-input"
-    ) as HTMLInputElement;
+    const tournamentNameEl = getById<HTMLInputElement>("tournament-name-input");
     const selectionEl = document.querySelector(
       'input[name="players"]'
     ) as HTMLInputElement;
-    const tournamentErrorEl = document.getElementById(
-      "tournament-name-error"
-    ) as HTMLElement;
-    const playerErrorEl = document.getElementById(
-      "player-error"
-    ) as HTMLElement;
+    const tournamentErrorEl = getById<HTMLElement>("tournament-name-error");
+    const playerErrorEl = getById<HTMLElement>("player-error");
     let isValid = true;
 
     if (

--- a/app/frontend/src/views/PlayerNicknamesView.ts
+++ b/app/frontend/src/views/PlayerNicknamesView.ts
@@ -5,7 +5,7 @@ import { createTournament } from "../services/tournamentService.js";
 import { validateNicknames } from "../validate.js";
 import { router } from "../routing/Router.js";
 import { auth } from "../AuthManager.js";
-import { escapeHTML } from "../utility.js";
+import { escapeHTML, getById } from "../utility.js";
 import { NicknameInput } from "../components/NicknameInput.js";
 import { Header1 } from "../components/Header1.js";
 import { Paragraph } from "../components/Paragraph.js";
@@ -63,13 +63,13 @@ export default class PlayerNicknamesView extends AbstractView {
 
   async render() {
     this.updateHTML();
-    this.formEl = document.querySelector("#nicknames-form")!;
+    this.formEl = getById("nicknames-form");
     this.addListeners();
   }
 
   private async validateAndStartTournament(event: Event) {
     event.preventDefault();
-    const form = document.getElementById("nicknames-form") as HTMLFormElement;
+    const form = getById<HTMLFormElement>("nicknames-form");
     const formData = new FormData(form);
     const userNumber = formData.get("userChoice");
     const inputElements: HTMLInputElement[] = Array.from(

--- a/app/frontend/src/views/PlayerNicknamesView.ts
+++ b/app/frontend/src/views/PlayerNicknamesView.ts
@@ -5,7 +5,7 @@ import { createTournament } from "../services/tournamentService.js";
 import { validateNicknames } from "../validate.js";
 import { router } from "../routing/Router.js";
 import { auth } from "../AuthManager.js";
-import { escapeHTML, getById } from "../utility.js";
+import { escapeHTML, getAllBySelector, getById } from "../utility.js";
 import { NicknameInput } from "../components/NicknameInput.js";
 import { Header1 } from "../components/Header1.js";
 import { Paragraph } from "../components/Paragraph.js";
@@ -72,11 +72,13 @@ export default class PlayerNicknamesView extends AbstractView {
     const form = getById<HTMLFormElement>("nicknames-form");
     const formData = new FormData(form);
     const userNumber = formData.get("userChoice");
-    const inputElements: HTMLInputElement[] = Array.from(
-      this.formEl.querySelectorAll("input[type='text']")
+    const inputElements = getAllBySelector<HTMLInputElement>(
+      "input[type='text']",
+      { root: this.formEl }
     );
-    const errorElements: HTMLElement[] = Array.from(
-      this.formEl.querySelectorAll('[id^="player-error-"]')
+    const errorElements = getAllBySelector<HTMLElement>(
+      '[id^="player-error-"]',
+      { root: this.formEl }
     );
     const nicknames = inputElements.map((input) => input.value);
 

--- a/app/frontend/src/views/PlayerNicknamesView.ts
+++ b/app/frontend/src/views/PlayerNicknamesView.ts
@@ -69,8 +69,7 @@ export default class PlayerNicknamesView extends AbstractView {
 
   private async validateAndStartTournament(event: Event) {
     event.preventDefault();
-    const form = getById<HTMLFormElement>("nicknames-form");
-    const formData = new FormData(form);
+    const formData = new FormData(this.formEl);
     const userNumber = formData.get("userChoice");
     const inputElements = getAllBySelector<HTMLInputElement>(
       "input[type='text']",

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -213,9 +213,9 @@ export default class ProfileView extends AbstractView {
 
   async render(): Promise<void> {
     this.updateHTML();
-    this.avatarFormEl = document.querySelector("#avatar-upload-form")!;
-    this.profileFormEl = document.querySelector("#profile-form")!;
-    this.passwordFormEl = document.querySelector("#password-form")!;
+    this.avatarFormEl = getById<HTMLFormElement>("avatar-upload-form");
+    this.profileFormEl = getById<HTMLFormElement>("profile-form");
+    this.passwordFormEl = getById<HTMLFormElement>("password-form");
     this.avatarInputEl = getById<HTMLInputElement>("avatar-input");
     this.fileLabelEl = getById<HTMLInputElement>("avatar-input-file-label");
     this.addListeners();

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -213,11 +213,11 @@ export default class ProfileView extends AbstractView {
 
   async render(): Promise<void> {
     this.updateHTML();
-    this.avatarFormEl = getById<HTMLFormElement>("avatar-upload-form");
-    this.profileFormEl = getById<HTMLFormElement>("profile-form");
-    this.passwordFormEl = getById<HTMLFormElement>("password-form");
-    this.avatarInputEl = getById<HTMLInputElement>("avatar-input");
-    this.fileLabelEl = getById<HTMLInputElement>("avatar-input-file-label");
+    this.avatarFormEl = getById("avatar-upload-form");
+    this.profileFormEl = getById("profile-form");
+    this.passwordFormEl = getById("password-form");
+    this.avatarInputEl = getById("avatar-input");
+    this.fileLabelEl = getById("avatar-input-file-label");
     this.addListeners();
   }
 
@@ -340,10 +340,10 @@ export default class ProfileView extends AbstractView {
       "current-password-input"
     );
     // FIXME: activate when pw policy active
-    // const currentPasswordErrorEl = getEl("current-password-error");
+    // const currentPasswordErrorEl = getById("current-password-error");
     const newPasswordEl = getById<HTMLInputElement>("new-password-input");
     // FIXME: activate when pw policy active
-    // const newPasswordErrorEl = getEl("new-password-error");
+    // const newPasswordErrorEl = getById("new-password-error");
     const confirmPasswordEl = getById<HTMLInputElement>(
       "confirm-new-password-input"
     );

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -3,7 +3,7 @@ import { Form } from "../components/Form.js";
 import { Input, addTogglePasswordListener } from "../components/Input.js";
 import { Button } from "../components/Button.js";
 import { Paragraph } from "../components/Paragraph.js";
-import { escapeHTML } from "../utility.js";
+import { escapeHTML, getById } from "../utility.js";
 import { auth } from "../AuthManager.js";
 import { uploadAvatar } from "../services/userServices.js";
 import {
@@ -16,7 +16,7 @@ import {
   clearInvalid,
   isEmptyString
 } from "../validate.js";
-import { getInputEl, getEl } from "../utility.js";
+import { getEl } from "../utility.js";
 import { patchUser, updateUserPassword } from "../services/userServices.js";
 import { User } from "../types/User.js";
 import { toaster } from "../Toaster.js";
@@ -217,8 +217,8 @@ export default class ProfileView extends AbstractView {
     this.avatarFormEl = document.querySelector("#avatar-upload-form")!;
     this.profileFormEl = document.querySelector("#profile-form")!;
     this.passwordFormEl = document.querySelector("#password-form")!;
-    this.avatarInputEl = getInputEl("avatar-input");
-    this.fileLabelEl = getInputEl("avatar-input-file-label");
+    this.avatarInputEl = getById<HTMLInputElement>("avatar-input");
+    this.fileLabelEl = getById<HTMLInputElement>("avatar-input-file-label");
     this.addListeners();
   }
 
@@ -227,7 +227,7 @@ export default class ProfileView extends AbstractView {
 
     let valid = true;
 
-    const usernameEl = getInputEl("username-input");
+    const usernameEl = getById<HTMLInputElement>("username-input");
     const usernameErrorEl = getEl("username-error");
     const username = usernameEl.value;
     const hasUsername = !isEmptyString(username);
@@ -241,7 +241,7 @@ export default class ProfileView extends AbstractView {
     let emailEl: HTMLInputElement | null = null;
     let email = "";
     if (this.hasLocalAuth) {
-      emailEl = getInputEl("email-input");
+      emailEl = getById<HTMLInputElement>("email-input");
       const emailErrorEl = getEl("email-error");
       email = emailEl.value;
       const hasEmail = !isEmptyString(email);
@@ -303,7 +303,7 @@ export default class ProfileView extends AbstractView {
 
   private async uploadAvatar(event: Event) {
     event.preventDefault();
-    const fileInputEl = getInputEl("avatar-input");
+    const fileInputEl = getById<HTMLInputElement>("avatar-input");
     const errorEl = getEl("avatar-upload-error-message");
 
     if (!validateImageFile(fileInputEl, errorEl)) return;
@@ -337,13 +337,17 @@ export default class ProfileView extends AbstractView {
   private async handlePasswordChange(event: Event) {
     event.preventDefault();
 
-    const currentPasswordEl = getInputEl("current-password-input");
+    const currentPasswordEl = getById<HTMLInputElement>(
+      "current-password-input"
+    );
     // FIXME: activate when pw policy active
     // const currentPasswordErrorEl = getEl("current-password-error");
-    const newPasswordEl = getInputEl("new-password-input");
+    const newPasswordEl = getById<HTMLInputElement>("new-password-input");
     // FIXME: activate when pw policy active
     // const newPasswordErrorEl = getEl("new-password-error");
-    const confirmPasswordEl = getInputEl("confirm-new-password-input");
+    const confirmPasswordEl = getById<HTMLInputElement>(
+      "confirm-new-password-input"
+    );
     const confirmPasswordErrorEl = getEl("confirm-error");
 
     if (

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -16,7 +16,6 @@ import {
   clearInvalid,
   isEmptyString
 } from "../validate.js";
-import { getEl } from "../utility.js";
 import { patchUser, updateUserPassword } from "../services/userServices.js";
 import { User } from "../types/User.js";
 import { toaster } from "../Toaster.js";
@@ -228,7 +227,7 @@ export default class ProfileView extends AbstractView {
     let valid = true;
 
     const usernameEl = getById<HTMLInputElement>("username-input");
-    const usernameErrorEl = getEl("username-error");
+    const usernameErrorEl = getById("username-error");
     const username = usernameEl.value;
     const hasUsername = !isEmptyString(username);
 
@@ -242,7 +241,7 @@ export default class ProfileView extends AbstractView {
     let email = "";
     if (this.hasLocalAuth) {
       emailEl = getById<HTMLInputElement>("email-input");
-      const emailErrorEl = getEl("email-error");
+      const emailErrorEl = getById("email-error");
       email = emailEl.value;
       const hasEmail = !isEmptyString(email);
 
@@ -304,7 +303,7 @@ export default class ProfileView extends AbstractView {
   private async uploadAvatar(event: Event) {
     event.preventDefault();
     const fileInputEl = getById<HTMLInputElement>("avatar-input");
-    const errorEl = getEl("avatar-upload-error-message");
+    const errorEl = getById("avatar-upload-error-message");
 
     if (!validateImageFile(fileInputEl, errorEl)) return;
 
@@ -348,7 +347,7 @@ export default class ProfileView extends AbstractView {
     const confirmPasswordEl = getById<HTMLInputElement>(
       "confirm-new-password-input"
     );
-    const confirmPasswordErrorEl = getEl("confirm-error");
+    const confirmPasswordErrorEl = getById("confirm-error");
 
     if (
       !validateConfirmPassword(

--- a/app/frontend/src/views/ProfileView.ts
+++ b/app/frontend/src/views/ProfileView.ts
@@ -227,7 +227,7 @@ export default class ProfileView extends AbstractView {
     let valid = true;
 
     const usernameEl = getById<HTMLInputElement>("username-input");
-    const usernameErrorEl = getById("username-error");
+    const usernameErrorEl = getById<HTMLSpanElement>("username-error");
     const username = usernameEl.value;
     const hasUsername = !isEmptyString(username);
 
@@ -241,7 +241,7 @@ export default class ProfileView extends AbstractView {
     let email = "";
     if (this.hasLocalAuth) {
       emailEl = getById<HTMLInputElement>("email-input");
-      const emailErrorEl = getById("email-error");
+      const emailErrorEl = getById<HTMLSpanElement>("email-error");
       email = emailEl.value;
       const hasEmail = !isEmptyString(email);
 
@@ -303,7 +303,7 @@ export default class ProfileView extends AbstractView {
   private async uploadAvatar(event: Event) {
     event.preventDefault();
     const fileInputEl = getById<HTMLInputElement>("avatar-input");
-    const errorEl = getById("avatar-upload-error-message");
+    const errorEl = getById<HTMLSpanElement>("avatar-upload-error-message");
 
     if (!validateImageFile(fileInputEl, errorEl)) return;
 
@@ -340,14 +340,14 @@ export default class ProfileView extends AbstractView {
       "current-password-input"
     );
     // FIXME: activate when pw policy active
-    // const currentPasswordErrorEl = getById("current-password-error");
+    // const currentPasswordErrorEl = getById<HTMLSpanElement>("current-password-error");
     const newPasswordEl = getById<HTMLInputElement>("new-password-input");
     // FIXME: activate when pw policy active
-    // const newPasswordErrorEl = getById("new-password-error");
+    // const newPasswordErrorEl = getById<HTMLSpanElement>("new-password-error");
     const confirmPasswordEl = getById<HTMLInputElement>(
       "confirm-new-password-input"
     );
-    const confirmPasswordErrorEl = getById("confirm-error");
+    const confirmPasswordErrorEl = getById<HTMLSpanElement>("confirm-error");
 
     if (
       !validateConfirmPassword(

--- a/app/frontend/src/views/RegisterView.ts
+++ b/app/frontend/src/views/RegisterView.ts
@@ -106,16 +106,16 @@ export default class Register extends AbstractView {
   private async validateAndRegisterUser(event: Event): Promise<void> {
     event.preventDefault();
     const emailEL = getById<HTMLInputElement>("email");
-    const emailErrorEl = getById("email-error");
+    const emailErrorEl = getById<HTMLSpanElement>("email-error");
 
     const userEl = getById<HTMLInputElement>("username");
-    const userErrorEl = getById("username-error");
+    const userErrorEl = getById<HTMLSpanElement>("username-error");
 
     const passwordEl = getById<HTMLInputElement>("password");
-    const passwordErrorEl = getById("password-error");
+    const passwordErrorEl = getById<HTMLSpanElement>("password-error");
 
     const confirmPasswordEl = getById<HTMLInputElement>("confirm");
-    const confirmPasswordErrorEl = getById("confirm-error");
+    const confirmPasswordErrorEl = getById<HTMLSpanElement>("confirm-error");
 
     const isEmailValid = validateEmail(emailEL, emailErrorEl);
     const isUsernameValid = validateUsername(userEl, userErrorEl);

--- a/app/frontend/src/views/RegisterView.ts
+++ b/app/frontend/src/views/RegisterView.ts
@@ -8,7 +8,7 @@ import {
 import { registerUser } from "../services/userServices.js";
 import { router } from "../routing/Router.js";
 import { ApiError } from "../services/api.js";
-import { escapeHTML, getById, getEl } from "../utility.js";
+import { escapeHTML, getById } from "../utility.js";
 import { Header1 } from "../components/Header1.js";
 import { Input, addTogglePasswordListener } from "../components/Input.js";
 import { Button } from "../components/Button.js";
@@ -106,16 +106,16 @@ export default class Register extends AbstractView {
   private async validateAndRegisterUser(event: Event): Promise<void> {
     event.preventDefault();
     const emailEL = getById<HTMLInputElement>("email");
-    const emailErrorEl = getEl("email-error");
+    const emailErrorEl = getById("email-error");
 
     const userEl = getById<HTMLInputElement>("username");
-    const userErrorEl = getEl("username-error");
+    const userErrorEl = getById("username-error");
 
     const passwordEl = getById<HTMLInputElement>("password");
-    const passwordErrorEl = getEl("password-error");
+    const passwordErrorEl = getById("password-error");
 
     const confirmPasswordEl = getById<HTMLInputElement>("confirm");
-    const confirmPasswordErrorEl = getEl("confirm-error");
+    const confirmPasswordErrorEl = getById("confirm-error");
 
     const isEmailValid = validateEmail(emailEL, emailErrorEl);
     const isUsernameValid = validateUsername(userEl, userErrorEl);

--- a/app/frontend/src/views/RegisterView.ts
+++ b/app/frontend/src/views/RegisterView.ts
@@ -8,7 +8,7 @@ import {
 import { registerUser } from "../services/userServices.js";
 import { router } from "../routing/Router.js";
 import { ApiError } from "../services/api.js";
-import { escapeHTML, getEl, getInputEl } from "../utility.js";
+import { escapeHTML, getById, getEl } from "../utility.js";
 import { Header1 } from "../components/Header1.js";
 import { Input, addTogglePasswordListener } from "../components/Input.js";
 import { Button } from "../components/Button.js";
@@ -105,16 +105,16 @@ export default class Register extends AbstractView {
 
   private async validateAndRegisterUser(event: Event): Promise<void> {
     event.preventDefault();
-    const emailEL = getInputEl("email");
+    const emailEL = getById<HTMLInputElement>("email");
     const emailErrorEl = getEl("email-error");
 
-    const userEl = getInputEl("username");
+    const userEl = getById<HTMLInputElement>("username");
     const userErrorEl = getEl("username-error");
 
-    const passwordEl = getInputEl("password");
+    const passwordEl = getById<HTMLInputElement>("password");
     const passwordErrorEl = getEl("password-error");
 
-    const confirmPasswordEl = getInputEl("confirm");
+    const confirmPasswordEl = getById<HTMLInputElement>("confirm");
     const confirmPasswordErrorEl = getEl("confirm-error");
 
     const isEmailValid = validateEmail(emailEL, emailErrorEl);

--- a/app/frontend/src/views/SettingsView.ts
+++ b/app/frontend/src/views/SettingsView.ts
@@ -23,7 +23,7 @@ import { patchUser } from "../services/userServices.js";
 import { toaster } from "../Toaster.js";
 import { auth } from "../AuthManager.js";
 import { User, Language } from "../types/User.js";
-import { getById, getEl } from "../utility.js";
+import { getById } from "../utility.js";
 
 export default class SettingsView extends AbstractView {
   private hasLocalAuth: boolean = auth.getUser().authProvider === "LOCAL";
@@ -293,34 +293,34 @@ export default class SettingsView extends AbstractView {
 
   private initTwoFAElements(): void {
     this.twoFASetupButtonEl = getById<HTMLButtonElement>("setup-two-fa-button");
-    this.twoFAModalEl = getEl("two-fa-modal") as HTMLDialogElement;
-    this.twoFAFormEl = getEl("two-fa-form") as HTMLFormElement;
-    this.twoFAPasswordModalEl = getEl(
+    this.twoFAModalEl = getById<HTMLDialogElement>("two-fa-modal");
+    this.twoFAFormEl = getById<HTMLFormElement>("two-fa-form");
+    this.twoFAPasswordModalEl = getById<HTMLDialogElement>(
       "two-fa-password-modal"
-    ) as HTMLDialogElement;
-    this.twoFAPasswordFormEl = getEl("two-fa-password-form") as HTMLFormElement;
+    );
+    this.twoFAPasswordFormEl = getById<HTMLFormElement>("two-fa-password-form");
     this.twoFAPasswordInputEl = getById<HTMLInputElement>(
       "two-fa-password-input"
     );
-    this.twoFAPasswordInputErrorEl = getEl("two-fa-password-input-error");
-    this.twoFAQRCodeEl = getEl("two-fa-qr-code") as HTMLImageElement;
+    this.twoFAPasswordInputErrorEl = getById("two-fa-password-input-error");
+    this.twoFAQRCodeEl = getById<HTMLImageElement>("two-fa-qr-code");
 
     if (!this.hasTwoFA()) {
       this.twoFACodeInputEl = getById<HTMLInputElement>("two-fa-code-input");
-      this.twoFACodeInputErrorEl = getEl("two-fa-code-input-error");
+      this.twoFACodeInputErrorEl = getById("two-fa-code-input-error");
     } else {
       this.twoFAGenerateBackupCodesButtonEl = getById<HTMLButtonElement>(
         "two-fa-generate-backup-codes"
       );
-      this.twoFABackupCodesTableEl = getEl(
+      this.twoFABackupCodesTableEl = getById<HTMLTableElement>(
         "two-fa-backup-codes-table"
-      ) as HTMLTableElement;
-      this.twoFADownloadBackupCodesLinkEl = getEl(
+      );
+      this.twoFADownloadBackupCodesLinkEl = getById<HTMLAnchorElement>(
         "two-fa-download-backup-codes-link"
-      ) as HTMLAnchorElement;
-      this.twoFABackupCodesModalEl = getEl(
+      );
+      this.twoFABackupCodesModalEl = getById<HTMLDialogElement>(
         "two-fa-backup-codes-modal"
-      ) as HTMLDialogElement;
+      );
     }
   }
 
@@ -332,7 +332,7 @@ export default class SettingsView extends AbstractView {
     this.preferredLanguageButtonEl = getById<HTMLButtonElement>(
       "preferred-language-button"
     );
-    this.preferredLanguageOptionsEl = getEl("preferred-language-options");
+    this.preferredLanguageOptionsEl = getById("preferred-language-options");
     if (this.hasLocalAuth) this.initTwoFAElements();
     this.addListeners();
   }
@@ -573,7 +573,7 @@ export default class SettingsView extends AbstractView {
   }
 
   private displayModal(modalId: string): void {
-    const modal = getEl(modalId) as HTMLDialogElement;
+    const modal = getById<HTMLDialogElement>(modalId);
     modal.showModal();
   }
 
@@ -605,7 +605,7 @@ export default class SettingsView extends AbstractView {
   }
 
   private hideModal(modalId: string): void {
-    const modal = getEl(modalId) as HTMLDialogElement;
+    const modal = getById<HTMLDialogElement>(modalId);
     modal.close();
   }
 }

--- a/app/frontend/src/views/SettingsView.ts
+++ b/app/frontend/src/views/SettingsView.ts
@@ -326,9 +326,9 @@ export default class SettingsView extends AbstractView {
 
   async render(): Promise<void> {
     this.updateHTML();
-    this.preferredLanguageFormEl = document.querySelector<HTMLFormElement>(
-      "#preferred-language-form"
-    )!;
+    this.preferredLanguageFormEl = getById<HTMLFormElement>(
+      "preferred-language-form"
+    );
     this.preferredLanguageButtonEl = getById<HTMLButtonElement>(
       "preferred-language-button"
     );

--- a/app/frontend/src/views/SettingsView.ts
+++ b/app/frontend/src/views/SettingsView.ts
@@ -292,46 +292,34 @@ export default class SettingsView extends AbstractView {
   }
 
   private initTwoFAElements(): void {
-    this.twoFASetupButtonEl = getById<HTMLButtonElement>("setup-two-fa-button");
-    this.twoFAModalEl = getById<HTMLDialogElement>("two-fa-modal");
-    this.twoFAFormEl = getById<HTMLFormElement>("two-fa-form");
-    this.twoFAPasswordModalEl = getById<HTMLDialogElement>(
-      "two-fa-password-modal"
-    );
-    this.twoFAPasswordFormEl = getById<HTMLFormElement>("two-fa-password-form");
-    this.twoFAPasswordInputEl = getById<HTMLInputElement>(
-      "two-fa-password-input"
-    );
+    this.twoFASetupButtonEl = getById("setup-two-fa-button");
+    this.twoFAModalEl = getById("two-fa-modal");
+    this.twoFAFormEl = getById("two-fa-form");
+    this.twoFAPasswordModalEl = getById("two-fa-password-modal");
+    this.twoFAPasswordFormEl = getById("two-fa-password-form");
+    this.twoFAPasswordInputEl = getById("two-fa-password-input");
     this.twoFAPasswordInputErrorEl = getById("two-fa-password-input-error");
-    this.twoFAQRCodeEl = getById<HTMLImageElement>("two-fa-qr-code");
+    this.twoFAQRCodeEl = getById("two-fa-qr-code");
 
     if (!this.hasTwoFA()) {
-      this.twoFACodeInputEl = getById<HTMLInputElement>("two-fa-code-input");
+      this.twoFACodeInputEl = getById("two-fa-code-input");
       this.twoFACodeInputErrorEl = getById("two-fa-code-input-error");
     } else {
-      this.twoFAGenerateBackupCodesButtonEl = getById<HTMLButtonElement>(
+      this.twoFAGenerateBackupCodesButtonEl = getById(
         "two-fa-generate-backup-codes"
       );
-      this.twoFABackupCodesTableEl = getById<HTMLTableElement>(
-        "two-fa-backup-codes-table"
-      );
-      this.twoFADownloadBackupCodesLinkEl = getById<HTMLAnchorElement>(
+      this.twoFABackupCodesTableEl = getById("two-fa-backup-codes-table");
+      this.twoFADownloadBackupCodesLinkEl = getById(
         "two-fa-download-backup-codes-link"
       );
-      this.twoFABackupCodesModalEl = getById<HTMLDialogElement>(
-        "two-fa-backup-codes-modal"
-      );
+      this.twoFABackupCodesModalEl = getById("two-fa-backup-codes-modal");
     }
   }
 
   async render(): Promise<void> {
     this.updateHTML();
-    this.preferredLanguageFormEl = getById<HTMLFormElement>(
-      "preferred-language-form"
-    );
-    this.preferredLanguageButtonEl = getById<HTMLButtonElement>(
-      "preferred-language-button"
-    );
+    this.preferredLanguageFormEl = getById("preferred-language-form");
+    this.preferredLanguageButtonEl = getById("preferred-language-button");
     this.preferredLanguageOptionsEl = getById("preferred-language-options");
     if (this.hasLocalAuth) this.initTwoFAElements();
     this.addListeners();

--- a/app/frontend/src/views/SettingsView.ts
+++ b/app/frontend/src/views/SettingsView.ts
@@ -23,7 +23,7 @@ import { patchUser } from "../services/userServices.js";
 import { toaster } from "../Toaster.js";
 import { auth } from "../AuthManager.js";
 import { User, Language } from "../types/User.js";
-import { getById } from "../utility.js";
+import { getAllBySelector, getById, getBySelector } from "../utility.js";
 
 export default class SettingsView extends AbstractView {
   private hasLocalAuth: boolean = auth.getUser().authProvider === "LOCAL";
@@ -278,15 +278,15 @@ export default class SettingsView extends AbstractView {
       this.preferredLanguageOptionsEl.classList.toggle("hidden");
     });
 
-    this.preferredLanguageOptionsEl
-      .querySelectorAll("button[data-lang]")
-      .forEach((btn) => {
-        btn.addEventListener("click", async (e) => {
-          const lang = (e.currentTarget as HTMLElement).dataset
-            .lang as Language;
-          await auth.updateLanguage(lang);
-        });
+    const buttons = getAllBySelector<HTMLButtonElement>("button[data-lang]", {
+      root: this.preferredLanguageOptionsEl
+    });
+    buttons.forEach((btn) => {
+      btn.addEventListener("click", async (e) => {
+        const lang = (e.currentTarget as HTMLElement).dataset.lang as Language;
+        await auth.updateLanguage(lang);
       });
+    });
 
     document.addEventListener("click", this.onDocumentClick);
   }
@@ -581,10 +581,9 @@ export default class SettingsView extends AbstractView {
     action: "setup" | "remove" | "backupCodes"
   ): Promise<void> {
     this.passwordFormAction = action;
-    const labelEl = document.querySelector<HTMLLabelElement>(
+    const labelEl = getBySelector<HTMLLabelElement>(
       `label[for="two-fa-password-input"]`
     );
-    if (!labelEl) throw new Error("Modal labelEl not found");
 
     switch (action) {
       case "setup":

--- a/app/frontend/src/views/SettingsView.ts
+++ b/app/frontend/src/views/SettingsView.ts
@@ -23,7 +23,7 @@ import { patchUser } from "../services/userServices.js";
 import { toaster } from "../Toaster.js";
 import { auth } from "../AuthManager.js";
 import { User, Language } from "../types/User.js";
-import { getButtonEl, getEl, getInputEl } from "../utility.js";
+import { getButtonEl, getById, getEl } from "../utility.js";
 
 export default class SettingsView extends AbstractView {
   private hasLocalAuth: boolean = auth.getUser().authProvider === "LOCAL";
@@ -299,12 +299,14 @@ export default class SettingsView extends AbstractView {
       "two-fa-password-modal"
     ) as HTMLDialogElement;
     this.twoFAPasswordFormEl = getEl("two-fa-password-form") as HTMLFormElement;
-    this.twoFAPasswordInputEl = getInputEl("two-fa-password-input");
+    this.twoFAPasswordInputEl = getById<HTMLInputElement>(
+      "two-fa-password-input"
+    );
     this.twoFAPasswordInputErrorEl = getEl("two-fa-password-input-error");
     this.twoFAQRCodeEl = getEl("two-fa-qr-code") as HTMLImageElement;
 
     if (!this.hasTwoFA()) {
-      this.twoFACodeInputEl = getInputEl("two-fa-code-input");
+      this.twoFACodeInputEl = getById<HTMLInputElement>("two-fa-code-input");
       this.twoFACodeInputErrorEl = getEl("two-fa-code-input-error");
     } else {
       this.twoFAGenerateBackupCodesButtonEl = getButtonEl(

--- a/app/frontend/src/views/SettingsView.ts
+++ b/app/frontend/src/views/SettingsView.ts
@@ -23,7 +23,7 @@ import { patchUser } from "../services/userServices.js";
 import { toaster } from "../Toaster.js";
 import { auth } from "../AuthManager.js";
 import { User, Language } from "../types/User.js";
-import { getButtonEl, getById, getEl } from "../utility.js";
+import { getById, getEl } from "../utility.js";
 
 export default class SettingsView extends AbstractView {
   private hasLocalAuth: boolean = auth.getUser().authProvider === "LOCAL";
@@ -292,7 +292,7 @@ export default class SettingsView extends AbstractView {
   }
 
   private initTwoFAElements(): void {
-    this.twoFASetupButtonEl = getButtonEl("setup-two-fa-button");
+    this.twoFASetupButtonEl = getById<HTMLButtonElement>("setup-two-fa-button");
     this.twoFAModalEl = getEl("two-fa-modal") as HTMLDialogElement;
     this.twoFAFormEl = getEl("two-fa-form") as HTMLFormElement;
     this.twoFAPasswordModalEl = getEl(
@@ -309,7 +309,7 @@ export default class SettingsView extends AbstractView {
       this.twoFACodeInputEl = getById<HTMLInputElement>("two-fa-code-input");
       this.twoFACodeInputErrorEl = getEl("two-fa-code-input-error");
     } else {
-      this.twoFAGenerateBackupCodesButtonEl = getButtonEl(
+      this.twoFAGenerateBackupCodesButtonEl = getById<HTMLButtonElement>(
         "two-fa-generate-backup-codes"
       );
       this.twoFABackupCodesTableEl = getEl(
@@ -329,7 +329,9 @@ export default class SettingsView extends AbstractView {
     this.preferredLanguageFormEl = document.querySelector<HTMLFormElement>(
       "#preferred-language-form"
     )!;
-    this.preferredLanguageButtonEl = getButtonEl("preferred-language-button");
+    this.preferredLanguageButtonEl = getById<HTMLButtonElement>(
+      "preferred-language-button"
+    );
     this.preferredLanguageOptionsEl = getEl("preferred-language-options");
     if (this.hasLocalAuth) this.initTwoFAElements();
     this.addListeners();

--- a/app/frontend/src/views/StatsView.ts
+++ b/app/frontend/src/views/StatsView.ts
@@ -4,7 +4,7 @@ import {
   getUserStatsByUsername
 } from "../services/userStatsServices.js";
 import { getUserByUsername } from "../services/userServices.js";
-import { escapeHTML } from "../utility.js";
+import { escapeHTML, getById } from "../utility.js";
 import { auth } from "../AuthManager.js";
 import { Header1 } from "../components/Header1.js";
 import { router } from "../routing/Router.js";
@@ -151,7 +151,7 @@ export default class StatsView extends AbstractView {
     }
     this.currentTabId = tabId;
 
-    const container = document.getElementById("tab-content")!;
+    const container = getById<HTMLDivElement>("tab-content");
     container.innerHTML = this.tabs[tabId].getHTML();
 
     await this.tabs[tabId].onShow();

--- a/app/frontend/src/views/StatsView.ts
+++ b/app/frontend/src/views/StatsView.ts
@@ -4,7 +4,7 @@ import {
   getUserStatsByUsername
 } from "../services/userStatsServices.js";
 import { getUserByUsername } from "../services/userServices.js";
-import { escapeHTML, getById } from "../utility.js";
+import { escapeHTML, getAllBySelector, getById } from "../utility.js";
 import { auth } from "../AuthManager.js";
 import { Header1 } from "../components/Header1.js";
 import { router } from "../routing/Router.js";
@@ -187,7 +187,7 @@ export default class StatsView extends AbstractView {
   }
 
   protected addListeners(): void {
-    const buttons = document.querySelectorAll<HTMLButtonElement>(".tab-button");
+    const buttons = getAllBySelector<HTMLButtonElement>(".tab-button");
 
     buttons.forEach((button) => {
       button.addEventListener("click", async () => {

--- a/app/frontend/src/views/TwoFABackupCodeVerifyView.ts
+++ b/app/frontend/src/views/TwoFABackupCodeVerifyView.ts
@@ -10,7 +10,7 @@ import { router } from "../routing/Router.js";
 import { Input } from "../components/Input.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
-import { getEl } from "../utility.js";
+import { getById } from "../utility.js";
 import { verifyBackupCode } from "../services/authServices.js";
 import { ApiError } from "../services/api.js";
 
@@ -61,10 +61,10 @@ export default class TwoFABackupCodeVerifyView extends AbstractView {
 
   private async verifTwoFABackupCode(event: Event) {
     event.preventDefault();
-    const twoFABackupCodeInput = getEl(
+    const twoFABackupCodeInput = getById<HTMLInputElement>(
       "two-fa-backup-code-input"
-    ) as HTMLInputElement;
-    const twoFABackupCodeErrorEl = getEl("two-fa-backup-code-input-error");
+    );
+    const twoFABackupCodeErrorEl = getById("two-fa-backup-code-input-error");
 
     const isBackupCodeValid = await validateTwoFABackupCode(
       twoFABackupCodeInput,

--- a/app/frontend/src/views/TwoFABackupCodeVerifyView.ts
+++ b/app/frontend/src/views/TwoFABackupCodeVerifyView.ts
@@ -64,7 +64,9 @@ export default class TwoFABackupCodeVerifyView extends AbstractView {
     const twoFABackupCodeInput = getById<HTMLInputElement>(
       "two-fa-backup-code-input"
     );
-    const twoFABackupCodeErrorEl = getById("two-fa-backup-code-input-error");
+    const twoFABackupCodeErrorEl = getById<HTMLSpanElement>(
+      "two-fa-backup-code-input-error"
+    );
 
     const isBackupCodeValid = await validateTwoFABackupCode(
       twoFABackupCodeInput,

--- a/app/frontend/src/views/TwoFAVerifyView.ts
+++ b/app/frontend/src/views/TwoFAVerifyView.ts
@@ -70,7 +70,9 @@ export default class TwoFAVerifyView extends AbstractView {
   private async verifyTwoFA(event: Event) {
     event.preventDefault();
     const twoFAQRCodeInput = getById<HTMLInputElement>("two-fa-qr-code-input");
-    const twoFAQRCodeErrorEl = getById("two-fa-qr-code-input-error");
+    const twoFAQRCodeErrorEl = getById<HTMLSpanElement>(
+      "two-fa-qr-code-input-error"
+    );
 
     const isTwoFACodeValid = await validateTwoFACode(
       twoFAQRCodeInput,

--- a/app/frontend/src/views/TwoFAVerifyView.ts
+++ b/app/frontend/src/views/TwoFAVerifyView.ts
@@ -7,7 +7,7 @@ import { router } from "../routing/Router.js";
 import { Input } from "../components/Input.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
-import { getEl } from "../utility.js";
+import { getById } from "../utility.js";
 import { verifyLoginTwoFACode } from "../services/authServices.js";
 import { ApiError } from "../services/api.js";
 import { Link } from "../components/Link.js";
@@ -69,8 +69,8 @@ export default class TwoFAVerifyView extends AbstractView {
 
   private async verifyTwoFA(event: Event) {
     event.preventDefault();
-    const twoFAQRCodeInput = getEl("two-fa-qr-code-input") as HTMLInputElement;
-    const twoFAQRCodeErrorEl = getEl("two-fa-qr-code-input-error");
+    const twoFAQRCodeInput = getById<HTMLInputElement>("two-fa-qr-code-input");
+    const twoFAQRCodeErrorEl = getById("two-fa-qr-code-input-error");
 
     const isTwoFACodeValid = await validateTwoFACode(
       twoFAQRCodeInput,

--- a/app/frontend/src/views/tabs/FriendsTab.ts
+++ b/app/frontend/src/views/tabs/FriendsTab.ts
@@ -8,7 +8,7 @@ import { getDataOrThrow } from "../../services/api.js";
 import { getUserDashboardFriends } from "../../services/userStatsServices.js";
 import { toaster } from "../../Toaster.js";
 import { DashboardFriends, FriendStatsSeries } from "../../types/DataSeries.js";
-import { getEl } from "../../utility.js";
+import { getById } from "../../utility.js";
 import { AbstractTab } from "./AbstractTab.js";
 
 export class FriendsTab extends AbstractTab {
@@ -97,7 +97,7 @@ export class FriendsTab extends AbstractTab {
       console.warn("No friends to display");
       return;
     }
-    const container = getEl("friend-selector");
+    const container = getById<HTMLDivElement>("friend-selector");
     const selectedFriends = this.friendManager.getSelectedFriends();
 
     friends.forEach((friend) => {
@@ -147,7 +147,7 @@ export class FriendsTab extends AbstractTab {
     } else {
       button.dataset.selected = "false";
     }
-    const container = getEl("friend-selector");
+    const container = getById<HTMLDivElement>("friend-selector");
     const buttons = container.querySelectorAll("button");
     buttons.forEach((btn) => {
       const selected = btn.dataset.selected === "true";

--- a/app/frontend/src/views/tabs/FriendsTab.ts
+++ b/app/frontend/src/views/tabs/FriendsTab.ts
@@ -8,7 +8,7 @@ import { getDataOrThrow } from "../../services/api.js";
 import { getUserDashboardFriends } from "../../services/userStatsServices.js";
 import { toaster } from "../../Toaster.js";
 import { DashboardFriends, FriendStatsSeries } from "../../types/DataSeries.js";
-import { getById } from "../../utility.js";
+import { getAllBySelector, getById } from "../../utility.js";
 import { AbstractTab } from "./AbstractTab.js";
 
 export class FriendsTab extends AbstractTab {
@@ -148,7 +148,10 @@ export class FriendsTab extends AbstractTab {
       button.dataset.selected = "false";
     }
     const container = getById<HTMLDivElement>("friend-selector");
-    const buttons = container.querySelectorAll("button");
+    const buttons = getAllBySelector<HTMLButtonElement>("button", {
+      root: container,
+      strict: false
+    });
     buttons.forEach((btn) => {
       const selected = btn.dataset.selected === "true";
       if (!selected) {

--- a/app/frontend/src/views/tabs/MatchesTab.ts
+++ b/app/frontend/src/views/tabs/MatchesTab.ts
@@ -13,6 +13,7 @@ import { getUserDashboardMatchesByUsername } from "../../services/userStatsServi
 import { DashboardMatches } from "../../types/DataSeries.js";
 import { Match } from "../../types/IMatch.js";
 import { UserStats } from "../../types/IUserStats.js";
+import { getById } from "../../utility.js";
 import { PaginatedTab } from "./PaginatedTab.js";
 
 export class MatchesTab extends PaginatedTab<Match> {
@@ -83,8 +84,7 @@ export class MatchesTab extends PaginatedTab<Match> {
   }
 
   protected updateTable(matches: Match[]): void {
-    const table = document.getElementById("match-history-table");
-    if (!table) return;
+    const table = getById<HTMLTableElement>("match-history-table");
 
     const matchesRows =
       matches.length === 0

--- a/app/frontend/src/views/tabs/PaginatedTab.ts
+++ b/app/frontend/src/views/tabs/PaginatedTab.ts
@@ -2,6 +2,7 @@ import { AbstractTab } from "./AbstractTab.js";
 import { Paginator } from "../../Paginator.js";
 import { FetchPageResult } from "../../types/FetchPageResult.js";
 import { toaster } from "../../Toaster.js";
+import { getById } from "../../utility.js";
 
 export abstract class PaginatedTab<T> extends AbstractTab {
   protected paginator: Paginator<T>;
@@ -29,15 +30,9 @@ export abstract class PaginatedTab<T> extends AbstractTab {
   ): Promise<FetchPageResult<T>>;
 
   protected updatePaginationControls() {
-    const prevBtn = document.querySelector<HTMLButtonElement>(
-      `#${this.prevBtnId}`
-    );
-    const nextBtn = document.querySelector<HTMLButtonElement>(
-      `#${this.nextBtnId}`
-    );
-    const pageIndicator = document.querySelector<HTMLSpanElement>(
-      `#${this.indicatorId}`
-    );
+    const prevBtn = getById<HTMLButtonElement>(`${this.prevBtnId}`);
+    const nextBtn = getById<HTMLButtonElement>(`${this.nextBtnId}`);
+    const pageIndicator = getById<HTMLSpanElement>(`${this.indicatorId}`);
     if (!prevBtn || !nextBtn || !pageIndicator) return;
 
     prevBtn.disabled = !this.paginator.canGoPrev();
@@ -72,12 +67,8 @@ export abstract class PaginatedTab<T> extends AbstractTab {
   }
 
   protected addPaginationListeners() {
-    const prevBtn = document.querySelector<HTMLButtonElement>(
-      `#${this.prevBtnId}`
-    );
-    const nextBtn = document.querySelector<HTMLButtonElement>(
-      `#${this.nextBtnId}`
-    );
+    const prevBtn = getById<HTMLButtonElement>(`${this.prevBtnId}`);
+    const nextBtn = getById<HTMLButtonElement>(`${this.nextBtnId}`);
     if (!prevBtn || !nextBtn) return;
 
     prevBtn.addEventListener("click", async () => {

--- a/app/frontend/src/views/tabs/TournamentsTab.ts
+++ b/app/frontend/src/views/tabs/TournamentsTab.ts
@@ -16,6 +16,7 @@ import {
 } from "../../components/TournamentRow.js";
 import { Table } from "../../components/Table.js";
 import { getUserTournaments } from "../../services/tournamentService.js";
+import { getById } from "../../utility.js";
 
 export class TournamentsTab extends PaginatedTab<TournamentDTO> {
   private dashboard: DashboardTournaments | null = null;
@@ -107,8 +108,7 @@ export class TournamentsTab extends PaginatedTab<TournamentDTO> {
   }
 
   protected updateTable(tournaments: TournamentDTO[]): void {
-    const table = document.getElementById("tournament-history-table");
-    if (!table) return;
+    const table = getById<HTMLTableElement>("tournament-history-table");
 
     const tournamentsRows =
       tournaments.length === 0


### PR DESCRIPTION
### Refactor

- adds generic element selector functions `getBySelector()`, `getById()`, `getAllBySelector()`
- use case are for elements we know exist. They get element ref, check if it exists and then return it.
- if we get element in function variable we can add explicit type. If we get element in class variable we dont need to explicitly add type (since it is already typed by class variable)
- Replaced `getEl()`, `getInputEl()` and `getButtonEl()` which used hard casts with `as`. Also removed ! and ? operators: after it ran through function, we know element exists
- Replaced other instances of document.getElementById or document.querySelector
- There are still instances where we don't use these functions: 
    - check for sidebar on logout
    - container init in Toaster 
    - container in FriendStatusChange
    - --> I think we could remove all these, but didn't want to change these to not introduce bugs 
- Also added epxlicit typing for errorElements in validate functions as HTMLSpanElement