### PR TITLE
183 move bracket match creation to backend

### DIFF
--- a/app/backend/prisma/migrations/20250821095238_add_bracket_match_table_and_relations/migration.sql
+++ b/app/backend/prisma/migrations/20250821095238_add_bracket_match_table_and_relations/migration.sql
@@ -1,0 +1,51 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `bracket` on the `tournaments` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[tournamentId,bracketMatchNumber]` on the table `matches` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "matches" ADD COLUMN "bracketMatchNumber" INTEGER;
+
+-- CreateTable
+CREATE TABLE "bracket_matches" (
+    "tournamentId" INTEGER NOT NULL,
+    "matchNumber" INTEGER NOT NULL,
+    "round" INTEGER NOT NULL,
+    "player1Nickname" TEXT,
+    "player2Nickname" TEXT,
+    "player1Type" TEXT NOT NULL DEFAULT 'HUMAN',
+    "player2Type" TEXT NOT NULL DEFAULT 'HUMAN',
+    "winner" TEXT,
+    "nextMatchNumber" INTEGER,
+    "winnerSlot" INTEGER,
+
+    PRIMARY KEY ("tournamentId", "matchNumber"),
+    CONSTRAINT "bracket_matches_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "tournaments" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "bracket_matches_tournamentId_matchNumber_fkey" FOREIGN KEY ("tournamentId", "matchNumber") REFERENCES "matches" ("tournamentId", "bracketMatchNumber") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_tournaments" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "maxPlayers" INTEGER NOT NULL DEFAULT 4,
+    "isPrivate" BOOLEAN NOT NULL DEFAULT false,
+    "isFinished" BOOLEAN NOT NULL DEFAULT false,
+    "userId" INTEGER NOT NULL,
+    "userNickname" TEXT NOT NULL DEFAULT 'Mister Bombastic',
+    "roundReached" INTEGER NOT NULL DEFAULT 1,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "tournaments_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_tournaments" ("id", "isFinished", "isPrivate", "maxPlayers", "name", "roundReached", "updatedAt", "userId", "userNickname") SELECT "id", "isFinished", "isPrivate", "maxPlayers", "name", "roundReached", "updatedAt", "userId", "userNickname" FROM "tournaments";
+DROP TABLE "tournaments";
+ALTER TABLE "new_tournaments" RENAME TO "tournaments";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "matches_tournamentId_bracketMatchNumber_key" ON "matches"("tournamentId", "bracketMatchNumber");

--- a/app/backend/prisma/migrations/20250821110536_make_player_type_optional/migration.sql
+++ b/app/backend/prisma/migrations/20250821110536_make_player_type_optional/migration.sql
@@ -1,0 +1,24 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_bracket_matches" (
+    "tournamentId" INTEGER NOT NULL,
+    "matchNumber" INTEGER NOT NULL,
+    "round" INTEGER NOT NULL,
+    "player1Nickname" TEXT,
+    "player2Nickname" TEXT,
+    "player1Type" TEXT,
+    "player2Type" TEXT,
+    "winner" TEXT,
+    "nextMatchNumber" INTEGER,
+    "winnerSlot" INTEGER,
+
+    PRIMARY KEY ("tournamentId", "matchNumber"),
+    CONSTRAINT "bracket_matches_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "tournaments" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "bracket_matches_tournamentId_matchNumber_fkey" FOREIGN KEY ("tournamentId", "matchNumber") REFERENCES "matches" ("tournamentId", "bracketMatchNumber") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_bracket_matches" ("matchNumber", "nextMatchNumber", "player1Nickname", "player1Type", "player2Nickname", "player2Type", "round", "tournamentId", "winner", "winnerSlot") SELECT "matchNumber", "nextMatchNumber", "player1Nickname", "player1Type", "player2Nickname", "player2Type", "round", "tournamentId", "winner", "winnerSlot" FROM "bracket_matches";
+DROP TABLE "bracket_matches";
+ALTER TABLE "new_bracket_matches" RENAME TO "bracket_matches";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/app/backend/prisma/migrations/20250821111840_remove_relation_bracket_match_to_match/migration.sql
+++ b/app/backend/prisma/migrations/20250821111840_remove_relation_bracket_match_to_match/migration.sql
@@ -1,0 +1,23 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_bracket_matches" (
+    "tournamentId" INTEGER NOT NULL,
+    "matchNumber" INTEGER NOT NULL,
+    "round" INTEGER NOT NULL,
+    "player1Nickname" TEXT,
+    "player2Nickname" TEXT,
+    "player1Type" TEXT,
+    "player2Type" TEXT,
+    "winner" TEXT,
+    "nextMatchNumber" INTEGER,
+    "winnerSlot" INTEGER,
+
+    PRIMARY KEY ("tournamentId", "matchNumber"),
+    CONSTRAINT "bracket_matches_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "tournaments" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_bracket_matches" ("matchNumber", "nextMatchNumber", "player1Nickname", "player1Type", "player2Nickname", "player2Type", "round", "tournamentId", "winner", "winnerSlot") SELECT "matchNumber", "nextMatchNumber", "player1Nickname", "player1Type", "player2Nickname", "player2Type", "round", "tournamentId", "winner", "winnerSlot" FROM "bracket_matches";
+DROP TABLE "bracket_matches";
+ALTER TABLE "new_bracket_matches" RENAME TO "bracket_matches";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/app/backend/prisma/migrations/20250822134842_add_delete_cascade_for_bracket_match/migration.sql
+++ b/app/backend/prisma/migrations/20250822134842_add_delete_cascade_for_bracket_match/migration.sql
@@ -1,0 +1,23 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_bracket_matches" (
+    "tournamentId" INTEGER NOT NULL,
+    "matchNumber" INTEGER NOT NULL,
+    "round" INTEGER NOT NULL,
+    "player1Nickname" TEXT,
+    "player2Nickname" TEXT,
+    "player1Type" TEXT,
+    "player2Type" TEXT,
+    "winner" TEXT,
+    "nextMatchNumber" INTEGER,
+    "winnerSlot" INTEGER,
+
+    PRIMARY KEY ("tournamentId", "matchNumber"),
+    CONSTRAINT "bracket_matches_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "tournaments" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_bracket_matches" ("matchNumber", "nextMatchNumber", "player1Nickname", "player1Type", "player2Nickname", "player2Type", "round", "tournamentId", "winner", "winnerSlot") SELECT "matchNumber", "nextMatchNumber", "player1Nickname", "player1Type", "player2Nickname", "player2Type", "round", "tournamentId", "winner", "winnerSlot" FROM "bracket_matches";
+DROP TABLE "bracket_matches";
+ALTER TABLE "new_bracket_matches" RENAME TO "bracket_matches";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -96,21 +96,24 @@ model FriendRequest {
 }
 
 model Match {
-    id              Int        @id @default(autoincrement())
-    userId          Int
-    playedAs        PlayedAs   @default(PLAYERONE)
-    player1Nickname String
-    player2Nickname String
-    player1Score    Int
-    player2Score    Int
-    player1Type     PlayerType @default(HUMAN)
-    player2Type     PlayerType @default(HUMAN)
-    tournamentId    Int?
-    date            DateTime   @default(now())
+    id                 Int        @id @default(autoincrement())
+    userId             Int
+    playedAs           PlayedAs   @default(PLAYERONE)
+    player1Nickname    String
+    player2Nickname    String
+    player1Score       Int
+    player2Score       Int
+    player1Type        PlayerType @default(HUMAN)
+    player2Type        PlayerType @default(HUMAN)
+    tournamentId       Int?
+    bracketMatchNumber Int?
+    date               DateTime   @default(now())
 
-    user       User        @relation("UserPlayed", fields: [userId], references: [id], onDelete: Cascade)
-    tournament Tournament? @relation(fields: [tournamentId], references: [id])
+    user         User          @relation("UserPlayed", fields: [userId], references: [id], onDelete: Cascade)
+    tournament   Tournament?   @relation(fields: [tournamentId], references: [id])
+    bracketMatch BracketMatch? @relation
 
+    @@unique([tournamentId, bracketMatchNumber])
     @@map("matches")
 }
 
@@ -122,14 +125,33 @@ model Tournament {
     isFinished   Boolean  @default(false)
     userId       Int
     userNickname String   @default("Mister Bombastic")
-    bracket      Json
     roundReached Int      @default(1)
     updatedAt    DateTime @updatedAt
 
-    user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
-    matches Match[]
+    user           User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+    matches        Match[]
+    bracketMatches BracketMatch[]
 
     @@map("tournaments")
+}
+
+model BracketMatch {
+    tournamentId    Int
+    matchNumber     Int
+    round           Int
+    player1Nickname String?
+    player2Nickname String?
+    player1Type     PlayerType @default(HUMAN)
+    player2Type     PlayerType @default(HUMAN)
+    winner          String?
+    nextMatchNumber Int?
+    winnerSlot      Int?
+
+    tournament Tournament @relation(fields: [tournamentId], references: [id])
+    match      Match?     @relation(fields: [tournamentId, matchNumber], references: [tournamentId, bracketMatchNumber])
+
+    @@id([tournamentId, matchNumber])
+    @@map("bracket_matches")
 }
 
 enum PlayedAs {

--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -109,9 +109,8 @@ model Match {
     bracketMatchNumber Int?
     date               DateTime   @default(now())
 
-    user         User          @relation("UserPlayed", fields: [userId], references: [id], onDelete: Cascade)
-    tournament   Tournament?   @relation(fields: [tournamentId], references: [id])
-    bracketMatch BracketMatch? @relation
+    user       User        @relation("UserPlayed", fields: [userId], references: [id], onDelete: Cascade)
+    tournament Tournament? @relation(fields: [tournamentId], references: [id])
 
     @@unique([tournamentId, bracketMatchNumber])
     @@map("matches")
@@ -141,14 +140,13 @@ model BracketMatch {
     round           Int
     player1Nickname String?
     player2Nickname String?
-    player1Type     PlayerType @default(HUMAN)
-    player2Type     PlayerType @default(HUMAN)
+    player1Type     PlayerType?
+    player2Type     PlayerType?
     winner          String?
     nextMatchNumber Int?
     winnerSlot      Int?
 
     tournament Tournament @relation(fields: [tournamentId], references: [id])
-    match      Match?     @relation(fields: [tournamentId, matchNumber], references: [tournamentId, bracketMatchNumber])
 
     @@id([tournamentId, matchNumber])
     @@map("bracket_matches")

--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -146,7 +146,7 @@ model BracketMatch {
     nextMatchNumber Int?
     winnerSlot      Int?
 
-    tournament Tournament @relation(fields: [tournamentId], references: [id])
+    tournament Tournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
 
     @@id([tournamentId, matchNumber])
     @@map("bracket_matches")

--- a/app/backend/prisma/schema.prisma
+++ b/app/backend/prisma/schema.prisma
@@ -127,9 +127,9 @@ model Tournament {
     roundReached Int      @default(1)
     updatedAt    DateTime @updatedAt
 
-    user           User           @relation(fields: [userId], references: [id], onDelete: Cascade)
-    matches        Match[]
-    bracketMatches BracketMatch[]
+    user    User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+    matches Match[]
+    bracket BracketMatch[]
 
     @@map("tournaments")
 }

--- a/app/backend/prisma/seeders/seedMatches.ts
+++ b/app/backend/prisma/seeders/seedMatches.ts
@@ -13,8 +13,8 @@ import {
   randomIncrementalDateFactory
 } from "./utils.ts";
 
-import type { Match } from "../../../frontend/src/types/IMatch.ts";
 import type { User } from "@prisma/client";
+import { MatchRead } from "../../../frontend/src/types/IMatch.ts";
 
 export async function seedMatchesPerUser(
   users: User[],
@@ -23,7 +23,7 @@ export async function seedMatchesPerUser(
   winRateMin = 0,
   winRateMax = 1
 ) {
-  const allMatches: Match[] = [];
+  const allMatches: MatchRead[] = [];
 
   for (const user of users) {
     const matchCount = randNumber({ min, max });
@@ -40,7 +40,7 @@ export async function seedMatchesPerUser(
 }
 
 export async function seedMatches(userId: number, count = 10, winRate = 0.5) {
-  const matches: Match[] = [];
+  const matches: MatchRead[] = [];
   const nextDate = randomIncrementalDateFactory({
     from: randRecentDate({ days: 10 }),
     minStepMinutes: 1,

--- a/app/backend/prisma/seeders/seedMatches.ts
+++ b/app/backend/prisma/seeders/seedMatches.ts
@@ -14,7 +14,7 @@ import {
 } from "./utils.ts";
 
 import type { User } from "@prisma/client";
-import { MatchRead } from "../../../frontend/src/types/IMatch.ts";
+import type { MatchRead } from "../../../frontend/src/types/IMatch.ts";
 
 export async function seedMatchesPerUser(
   users: User[],

--- a/app/backend/prisma/seeders/seedMatches.ts
+++ b/app/backend/prisma/seeders/seedMatches.ts
@@ -75,7 +75,6 @@ export async function seedMatches(userId: number, count = 10, winRate = 0.5) {
       player2Score,
       "HUMAN",
       "HUMAN",
-      null,
       date
     );
 

--- a/app/backend/prisma/seeders/seedTournaments.ts
+++ b/app/backend/prisma/seeders/seedTournaments.ts
@@ -65,7 +65,7 @@ export async function seedSingleTournament(userId: number, winRate = 0.5) {
   const tournamentName = randNoun();
   const numberOfPlayers = rand([4, 8, 16]);
   const playerNicknames = Array.from({ length: numberOfPlayers }, () =>
-    randUserName({ withAccents: false })
+    randUserName({ withAccents: false }).slice(0, 20)
   );
   const userNickname = rand(playerNicknames);
   const playerTypes = new Array(numberOfPlayers).fill("HUMAN");

--- a/app/backend/prisma/seeders/seedTournaments.ts
+++ b/app/backend/prisma/seeders/seedTournaments.ts
@@ -93,19 +93,14 @@ export async function seedSingleTournament(userId: number, winRate = 0.5) {
       userNickname === nextMatch.player2Nickname;
     const userWins = userInMatch
       ? randChanceBoolean({ chanceTrue: winRate })
-      : null;
+      : false;
 
     const { player1Score, player2Score } = generateNonTiedScores(0, 10, {
-      winner:
-        userInMatch && userWins !== null
-          ? userNickname === nextMatch.player1Nickname
-            ? userWins
-              ? "PLAYERONE"
-              : "PLAYERTWO"
-            : userWins
-              ? "PLAYERTWO"
-              : "PLAYERONE"
-          : undefined
+      winner: userWins
+        ? userNickname === nextMatch.player1Nickname
+          ? "PLAYERONE"
+          : "PLAYERTWO"
+        : undefined
     });
 
     const winner =
@@ -119,8 +114,6 @@ export async function seedSingleTournament(userId: number, winRate = 0.5) {
 
     const date = dateFactory();
 
-    tournamentClass.updateBracketWithResult(nextMatch.matchNumber, winner);
-
     const playedAs =
       tournamentDTO.userNickname === nextMatch.player1Nickname
         ? "PLAYERONE"
@@ -128,11 +121,15 @@ export async function seedSingleTournament(userId: number, winRate = 0.5) {
           ? "PLAYERTWO"
           : "NONE";
 
+    const hasUserWon = nextMatch.winner === tournamentDTO.userNickname;
+
+    tournamentClass.updateBracketWithResult(nextMatch.matchNumber, winner);
     await transactionUpdateBracket(
       userId,
       player1Score,
       player2Score,
       playedAs,
+      hasUserWon,
       matchWithTid,
       date
     );
@@ -140,7 +137,6 @@ export async function seedSingleTournament(userId: number, winRate = 0.5) {
 
   const tournament = await updateTournament(tournamentDTO.id, userId, {
     isFinished: true,
-    roundReached: tournamentClass.getRoundReached(),
     updatedAt: dateFactory()
   });
   console.log(

--- a/app/backend/prisma/seeders/seedTournaments.ts
+++ b/app/backend/prisma/seeders/seedTournaments.ts
@@ -9,16 +9,19 @@ import {
   randUserName
 } from "@ngneat/falso";
 import { Tournament } from "../../../frontend/src/Tournament.ts";
+import { updateTournament } from "../../src/services/tournaments.services.js";
 import {
-  createTournament,
-  updateTournament
-} from "../../src/services/tournaments.services.js";
-import { transactionMatch } from "../../src/services/transactions.services.js";
+  transactionTournament,
+  transactionUpdateBracket
+} from "../../src/services/transactions.services.js";
 import { generateNonTiedScores } from "./utils.ts";
 
-import type { BracketMatch } from "../../../frontend/src/types/IMatch.ts";
-import type { Tournament as TournamentType, User } from "@prisma/client";
-type PublicTournament = Omit<TournamentType, "isPrivate">;
+import type { User } from "@prisma/client";
+import type { TournamentRead } from "../../../frontend/src/types/ITournament.ts";
+import type { BracketMatchRead } from "../../../frontend/src/types/BracketMatch.ts";
+type BracketMatchReadWithTournamentId = BracketMatchRead & {
+  tournamentId: number;
+};
 
 export async function seedTournamentsPerUser(
   users: User[],
@@ -27,7 +30,7 @@ export async function seedTournamentsPerUser(
   winRateMin = 0,
   winRateMax = 1
 ) {
-  const allTournaments: PublicTournament[] = [];
+  const allTournaments: TournamentRead[] = [];
 
   for (const user of users) {
     const tournamentCount = randNumber({ min, max });
@@ -48,7 +51,7 @@ export async function seedTournaments(
   count = 10,
   winRate = 0.5
 ) {
-  const tournaments: PublicTournament[] = [];
+  const tournaments: TournamentRead[] = [];
 
   for (let i = 0; i < count; i++) {
     const tournament = await seedSingleTournament(userId, winRate);
@@ -65,26 +68,17 @@ export async function seedSingleTournament(userId: number, winRate = 0.5) {
     randUserName({ withAccents: false })
   );
   const userNickname = rand(playerNicknames);
+  const playerTypes = new Array(numberOfPlayers).fill("HUMAN");
 
-  const tournamentClass = Tournament.fromUsernames(
-    playerNicknames,
-    tournamentName,
-    numberOfPlayers,
-    userNickname,
-    userId
-  );
-
-  const bracket = JSON.stringify(tournamentClass.getBracket());
-
-  const { id } = await createTournament(
+  const tournamentDTO: TournamentRead = await transactionTournament(
     tournamentName,
     numberOfPlayers,
     userId,
     userNickname,
-    bracket
+    playerNicknames,
+    playerTypes
   );
-
-  tournamentClass.setId(id);
+  const tournamentClass = new Tournament(tournamentDTO);
 
   const randomStartDate = randRecentDate({ days: 10 });
   const dateFactory = incrementalDate({
@@ -92,16 +86,11 @@ export async function seedSingleTournament(userId: number, winRate = 0.5) {
     step: 1 * 60 * 1000 // 1 minute in milliseconds
   });
 
-  let nextMatch: BracketMatch | null;
+  let nextMatch: BracketMatchRead | null;
   while ((nextMatch = tournamentClass.getNextMatchToPlay()) != null) {
-    const playedAs =
-      userNickname === nextMatch.player1!
-        ? "PLAYERONE"
-        : userNickname === nextMatch.player2!
-          ? "PLAYERTWO"
-          : "NONE";
-
-    const userInMatch = playedAs !== "NONE";
+    const userInMatch =
+      userNickname === nextMatch.player1Nickname ||
+      userNickname === nextMatch.player2Nickname;
     const userWins = userInMatch
       ? randChanceBoolean({ chanceTrue: winRate })
       : null;
@@ -109,7 +98,7 @@ export async function seedSingleTournament(userId: number, winRate = 0.5) {
     const { player1Score, player2Score } = generateNonTiedScores(0, 10, {
       winner:
         userInMatch && userWins !== null
-          ? playedAs === "PLAYERONE"
+          ? userNickname === nextMatch.player1Nickname
             ? userWins
               ? "PLAYERONE"
               : "PLAYERTWO"
@@ -120,30 +109,36 @@ export async function seedSingleTournament(userId: number, winRate = 0.5) {
     });
 
     const winner =
-      player1Score > player2Score ? nextMatch.player1! : nextMatch.player2!;
+      player1Score > player2Score
+        ? nextMatch.player1Nickname!
+        : nextMatch.player2Nickname!;
+    nextMatch.winner = winner;
+
+    const matchWithTid = nextMatch as BracketMatchReadWithTournamentId;
+    matchWithTid.tournamentId = tournamentDTO.id;
+
     const date = dateFactory();
 
-    tournamentClass.updateBracketWithResult(nextMatch.matchId, winner);
+    tournamentClass.updateBracketWithResult(nextMatch.matchNumber, winner);
 
-    await transactionMatch(
+    const playedAs =
+      tournamentDTO.userNickname === nextMatch.player1Nickname
+        ? "PLAYERONE"
+        : tournamentDTO.userNickname === nextMatch.player2Nickname
+          ? "PLAYERTWO"
+          : "NONE";
+
+    await transactionUpdateBracket(
       userId,
-      playedAs,
-      nextMatch.player1,
-      nextMatch.player2,
       player1Score,
       player2Score,
-      "HUMAN",
-      "HUMAN",
-      {
-        id: tournamentClass!.getId(),
-        name: tournamentClass!.getTournamentName()
-      },
+      playedAs,
+      matchWithTid,
       date
     );
   }
 
-  const tournament = await updateTournament(tournamentClass.getId(), userId, {
-    bracket: tournamentClass.getBracket(),
+  const tournament = await updateTournament(tournamentDTO.id, userId, {
     isFinished: true,
     roundReached: tournamentClass.getRoundReached(),
     updatedAt: dateFactory()

--- a/app/backend/src/controllers/matches.controllers.js
+++ b/app/backend/src/controllers/matches.controllers.js
@@ -18,8 +18,7 @@ export async function createMatchHandler(request, reply) {
       player1Type,
       player2Type,
       player1Score,
-      player2Score,
-      tournament
+      player2Score
     } = request.body;
     const date = new Date();
 
@@ -32,7 +31,6 @@ export async function createMatchHandler(request, reply) {
       player2Score,
       player1Type,
       player2Type,
-      tournament,
       date
     );
 

--- a/app/backend/src/controllers/tournaments.controllers.js
+++ b/app/backend/src/controllers/tournaments.controllers.js
@@ -7,7 +7,7 @@ import {
   getUserTournaments
 } from "../services/tournaments.services.js";
 import { createResponseMessage } from "../utils/response.js";
-import { handlePrismaError, httpError } from "../utils/error.js";
+import { httpError } from "../utils/error.js";
 import {
   transactionTournament,
   transactionUpdateBracket
@@ -89,83 +89,8 @@ export async function patchTournamentHandler(request, reply) {
 }
 
 export async function patchTournamentMatchHandler(request, reply) {
-  const action = "Patch tournament match";
-  try {
-    const tournamentId = request.params.id;
-    const matchNumber = request.params.matchNumber;
-    const userId = request.user.id;
-    const { player1Score, player2Score } = request.body;
-
-    const tournament = await getUserTournaments(userId, undefined, {
-      tournamentId
-    });
-    if (tournament.length === 0) {
-      return httpError(
-        reply,
-        404,
-        createResponseMessage(action, false),
-        "No record was found for an update."
-      );
-    }
-
-    const bracketMatch = await getBracketMatch(tournamentId, matchNumber);
-    if (bracketMatch.winner) {
-      return httpError(
-        reply,
-        400,
-        createResponseMessage(action, false),
-        "This bracket match already has a winner."
-      );
-    }
-
-    if (player1Score > player2Score) {
-      bracketMatch.winner = bracketMatch.player1Nickname;
-    } else if (player2Score > player1Score) {
-      bracketMatch.winner = bracketMatch.player2Nickname;
-    } else {
-      return httpError(
-        reply,
-        400,
-        createResponseMessage(action, false),
-        "Match cannot end in a draw"
-      );
-    }
-
-    const playedAs =
-      tournament.userNickname === bracketMatch.player1Nickname
-        ? "PLAYERONE"
-        : tournament.userNickname === bracketMatch.player2Nickname
-          ? "PLAYERTWO"
-          : "NONE";
-
-    const hasUserWon = bracketMatch.winner === tournament.userNickname;
-
-    const date = new Date();
-
-    const data = await transactionUpdateBracket(
-      userId,
-      player1Score,
-      player2Score,
-      playedAs,
-      hasUserWon,
-      bracketMatch,
-      date
-    );
-
-    return reply
-      .code(201)
-      .send({ message: createResponseMessage(action, true), data: data });
-  } catch (err) {
-    request.log.error(
-      { err, body: request.body },
-      `patchTournamentHandler: ${createResponseMessage(action, false)}`
-    );
-    return handlePrismaError(reply, action, err);
-  }
-}
-
-export async function patchTournamentMatchHandler(request, reply) {
   request.action = "Patch tournament match";
+
   const tournamentId = request.params.id;
   const matchNumber = request.params.matchNumber;
   const userId = request.user.id;

--- a/app/backend/src/controllers/tournaments.controllers.js
+++ b/app/backend/src/controllers/tournaments.controllers.js
@@ -3,7 +3,8 @@ import {
   getTournament,
   updateTournament,
   deleteAllTournaments,
-  deleteTournament
+  deleteTournament,
+  getUserTournaments
 } from "../services/tournaments.services.js";
 import { createResponseMessage } from "../utils/response.js";
 import { handlePrismaError, httpError } from "../utils/error.js";
@@ -125,13 +126,15 @@ export async function patchTournamentMatchHandler(request, reply) {
     const userId = request.user.id;
     const { player1Score, player2Score } = request.body;
 
-    const tournament = await getTournament(tournamentId);
-    if (tournament.userId !== userId) {
+    const tournament = await getUserTournaments(userId, undefined, {
+      tournamentId
+    });
+    if (tournament.length === 0) {
       return httpError(
         reply,
-        403,
+        404,
         createResponseMessage(action, false),
-        "You are not allowed to update match of this tournament"
+        "No record was found for an update."
       );
     }
 

--- a/app/backend/src/controllers/tournaments.controllers.js
+++ b/app/backend/src/controllers/tournaments.controllers.js
@@ -176,9 +176,12 @@ export async function patchTournamentMatchHandler(request, reply) {
       date
     );
 
-    await updateTournament(tournamentId, userId, {
-      roundReached: { increment: 1 }
-    });
+    const hasUserWon = bracketMatch.winner === tournament.userNickname;
+    if (hasUserWon) {
+      await updateTournament(tournamentId, userId, {
+        roundReached: { increment: 1 }
+      });
+    }
 
     return reply
       .code(200)

--- a/app/backend/src/controllers/tournaments.controllers.js
+++ b/app/backend/src/controllers/tournaments.controllers.js
@@ -172,6 +172,11 @@ export async function patchTournamentMatchHandler(request, reply) {
       playedAs,
       bracketMatch
     );
+
+    await updateTournament(tournamentId, userId, {
+      roundReached: { increment: 1 }
+    });
+
     return reply
       .code(200)
       .send({ message: createResponseMessage(action, true), data: data });

--- a/app/backend/src/controllers/tournaments.controllers.js
+++ b/app/backend/src/controllers/tournaments.controllers.js
@@ -183,7 +183,7 @@ export async function patchTournamentMatchHandler(request, reply) {
     );
 
     return reply
-      .code(200)
+      .code(201)
       .send({ message: createResponseMessage(action, true), data: data });
   } catch (err) {
     request.log.error(

--- a/app/backend/src/controllers/tournaments.controllers.js
+++ b/app/backend/src/controllers/tournaments.controllers.js
@@ -165,6 +165,8 @@ export async function patchTournamentMatchHandler(request, reply) {
           ? "PLAYERTWO"
           : "NONE";
 
+    const hasUserWon = bracketMatch.winner === tournament.userNickname;
+
     const date = new Date();
 
     const data = await transactionUpdateBracket(
@@ -172,16 +174,10 @@ export async function patchTournamentMatchHandler(request, reply) {
       player1Score,
       player2Score,
       playedAs,
+      hasUserWon,
       bracketMatch,
       date
     );
-
-    const hasUserWon = bracketMatch.winner === tournament.userNickname;
-    if (hasUserWon) {
-      await updateTournament(tournamentId, userId, {
-        roundReached: { increment: 1 }
-      });
-    }
 
     return reply
       .code(200)

--- a/app/backend/src/controllers/tournaments.controllers.js
+++ b/app/backend/src/controllers/tournaments.controllers.js
@@ -145,13 +145,6 @@ export async function patchTournamentMatchHandler(request, reply) {
       );
     }
 
-    const playedAs =
-      tournament.userNickname === bracketMatch.player1Nickname
-        ? "PLAYERONE"
-        : tournament.userNickname === bracketMatch.player2Nickname
-          ? "PLAYERTWO"
-          : "NONE";
-
     if (player1Score > player2Score) {
       bracketMatch.winner = bracketMatch.player1Nickname;
     } else if (player2Score > player1Score) {
@@ -165,12 +158,22 @@ export async function patchTournamentMatchHandler(request, reply) {
       );
     }
 
+    const playedAs =
+      tournament.userNickname === bracketMatch.player1Nickname
+        ? "PLAYERONE"
+        : tournament.userNickname === bracketMatch.player2Nickname
+          ? "PLAYERTWO"
+          : "NONE";
+
+    const date = new Date();
+
     const data = await transactionUpdateBracket(
       userId,
       player1Score,
       player2Score,
       playedAs,
-      bracketMatch
+      bracketMatch,
+      date
     );
 
     await updateTournament(tournamentId, userId, {

--- a/app/backend/src/routes/tournaments.routes.js
+++ b/app/backend/src/routes/tournaments.routes.js
@@ -4,7 +4,8 @@ import {
   getTournamentHandler,
   patchTournamentHandler,
   deleteAllTournamentsHandler,
-  deleteTournamentHandler
+  deleteTournamentHandler,
+  patchTournamentMatchHandler
 } from "../controllers/tournaments.controllers.js";
 import { authorizeUserAccess } from "../middleware/auth.js";
 import { errorResponses } from "../utils/error.js";
@@ -17,6 +18,12 @@ export default async function tournamentRoutes(fastify) {
   fastify.get("/:id", optionsGetTournament, getTournamentHandler);
 
   fastify.patch("/:id", optionsPatchTournament, patchTournamentHandler);
+
+  fastify.patch(
+    "/:id/matches/:matchNumber",
+    optionsPatchTournamentMatch,
+    patchTournamentMatchHandler
+  );
 
   fastify.delete("/", optionsDeleteAllTournaments, deleteAllTournamentsHandler);
 
@@ -51,6 +58,24 @@ const optionsPatchTournament = {
     body: { $ref: "patchTournamentSchema" },
     response: {
       200: { $ref: "tournamentResponseSchema" },
+      ...errorResponses
+    }
+  }
+};
+
+const optionsPatchTournamentMatch = {
+  onRequest: [authorizeUserAccess],
+  schema: {
+    params: {
+      type: "object",
+      properties: {
+        id: { $ref: "commonDefinitionsSchema#/definitions/id" },
+        matchNumber: { $ref: "commonDefinitionsSchema#/definitions/id" }
+      }
+    },
+    body: { $ref: "patchTournamentMatchSchema" },
+    response: {
+      //200: { $ref: "tournamentResponseSchema" },
       ...errorResponses
     }
   }

--- a/app/backend/src/routes/tournaments.routes.js
+++ b/app/backend/src/routes/tournaments.routes.js
@@ -75,7 +75,7 @@ const optionsPatchTournamentMatch = {
     },
     body: { $ref: "patchTournamentMatchSchema" },
     response: {
-      //200: { $ref: "tournamentResponseSchema" },
+      201: { $ref: "patchTournamentMatchResponseSchema" },
       ...errorResponses
     }
   }

--- a/app/backend/src/schema/matches.schema.js
+++ b/app/backend/src/schema/matches.schema.js
@@ -124,13 +124,6 @@ export const createMatchSchema = {
     player2Score: {
       $ref: "commonDefinitionsSchema#/definitions/score",
       description: "The score of player 2 in the match"
-    },
-    tournamentId: {
-      oneOf: [
-        { $ref: "commonDefinitionsSchema#/definitions/id" },
-        { type: "null" }
-      ],
-      description: "The tournament id if this match belongs to one"
     }
   },
   required: [

--- a/app/backend/src/schema/matches.schema.js
+++ b/app/backend/src/schema/matches.schema.js
@@ -45,19 +45,12 @@ const matchSchema = {
       $ref: "commonDefinitionsSchema#/definitions/datetime",
       description: "The date-time of the match"
     },
-    tournament: {
+    tournamentName: {
       oneOf: [
-        {
-          type: "object",
-          properties: {
-            id: { $ref: "commonDefinitionsSchema#/definitions/id" },
-            name: { type: "string" }
-          },
-          required: ["id", "name"]
-        },
+        { $ref: "tournamentDefinitionsSchema#/definitions/tournamentName" },
         { type: "null" }
       ],
-      description: "The tournament details if this match belongs to one"
+      description: "The tournament name if this match belongs to one"
     }
   },
   required: [
@@ -66,6 +59,8 @@ const matchSchema = {
     "player2Nickname",
     "player1Score",
     "player2Score",
+    "player1Type",
+    "player2Type",
     "date"
   ],
   additionalProperties: false
@@ -130,8 +125,11 @@ export const createMatchSchema = {
       $ref: "commonDefinitionsSchema#/definitions/score",
       description: "The score of player 2 in the match"
     },
-    tournament: {
-      oneOf: [{ $ref: "idSchema" }, { type: "null" }],
+    tournamentId: {
+      oneOf: [
+        { $ref: "commonDefinitionsSchema#/definitions/id" },
+        { type: "null" }
+      ],
       description: "The tournament id if this match belongs to one"
     }
   },
@@ -140,7 +138,9 @@ export const createMatchSchema = {
     "player1Nickname",
     "player2Nickname",
     "player1Score",
-    "player2Score"
+    "player2Score",
+    "player1Type",
+    "player2Type"
   ],
   additionalProperties: false
 };

--- a/app/backend/src/schema/tournaments.schema.js
+++ b/app/backend/src/schema/tournaments.schema.js
@@ -194,6 +194,21 @@ const patchTournamentSchema = {
   ]
 };
 
+const patchTournamentMatchSchema = {
+  $id: "patchTournamentMatchSchema",
+  type: "object",
+  properties: {
+    player1Score: {
+      $ref: "commonDefinitionsSchema#/definitions/score"
+    },
+    player2Score: {
+      $ref: "commonDefinitionsSchema#/definitions/score"
+    }
+  },
+  required: ["player1Score", "player2Score"],
+  additionalProperties: false
+};
+
 const querystringTournamentSchema = {
   $id: "querystringTournamentSchema",
   type: "object",
@@ -216,5 +231,6 @@ export const tournamentSchemas = [
   tournamentArrayResponseSchema,
   createTournamentSchema,
   patchTournamentSchema,
+  patchTournamentMatchSchema,
   querystringTournamentSchema
 ];

--- a/app/backend/src/schema/tournaments.schema.js
+++ b/app/backend/src/schema/tournaments.schema.js
@@ -194,6 +194,23 @@ const patchTournamentMatchSchema = {
   additionalProperties: false
 };
 
+const patchTournamentMatchResponseSchema = {
+  $id: "patchTournamentMatchResponseSchema",
+  type: "object",
+  properties: {
+    message: { type: "string" },
+    data: {
+      match: { $ref: "matchSchema" },
+      currentBracketMatch: { $ref: "bracketMatchSchema" },
+      nextBracketMatch: {
+        oneOf: [{ $ref: "bracketMatchSchema" }, { type: "null" }]
+      }
+    }
+  },
+  required: ["message", "data"],
+  additionalProperties: false
+};
+
 const querystringTournamentSchema = {
   $id: "querystringTournamentSchema",
   type: "object",
@@ -217,5 +234,6 @@ export const tournamentSchemas = [
   createTournamentSchema,
   patchTournamentSchema,
   patchTournamentMatchSchema,
+  patchTournamentMatchResponseSchema,
   querystringTournamentSchema
 ];

--- a/app/backend/src/schema/tournaments.schema.js
+++ b/app/backend/src/schema/tournaments.schema.js
@@ -93,7 +93,6 @@ export const tournamentSchema = {
     isFinished: {
       $ref: "tournamentDefinitionsSchema#/definitions/tournamentIsFinished"
     },
-    userId: { $ref: "commonDefinitionsSchema#/definitions/id" },
     userNickname: { $ref: "commonDefinitionsSchema#/definitions/username" },
     roundReached: {
       $ref: "tournamentDefinitionsSchema#/definitions/tournamentRoundReached"
@@ -106,7 +105,6 @@ export const tournamentSchema = {
     "name",
     "maxPlayers",
     "isFinished",
-    "userId",
     "userNickname",
     "roundReached"
   ],

--- a/app/backend/src/schema/tournaments.schema.js
+++ b/app/backend/src/schema/tournaments.schema.js
@@ -23,12 +23,61 @@ const tournamentDefinitionsSchema = {
       minimum: 1,
       description:
         "The round reached by player. Tournament was won if roundReached === log2(maxPlayers) + 1."
-    },
-    tournamentBracket: {
-      type: "string",
-      description: "Serialized match brackets"
     }
   }
+};
+
+const bracketMatchSchema = {
+  $id: "bracketMatchSchema",
+  type: "object",
+  properties: {
+    matchNumber: { type: "integer" },
+    round: { type: "integer" },
+    player1Nickname: {
+      oneOf: [
+        { $ref: "commonDefinitionsSchema#/definitions/username" },
+        { type: "null" }
+      ]
+    },
+    player2Nickname: {
+      oneOf: [
+        { $ref: "commonDefinitionsSchema#/definitions/username" },
+        { type: "null" }
+      ]
+    },
+    player1Type: {
+      oneOf: [
+        { $ref: "matchDefinitionsSchema#/definitions/playerType" },
+        { type: "null" }
+      ]
+    },
+    player2Type: {
+      oneOf: [
+        { $ref: "matchDefinitionsSchema#/definitions/playerType" },
+        { type: "null" }
+      ]
+    },
+    winner: {
+      oneOf: [
+        { $ref: "commonDefinitionsSchema#/definitions/username" },
+        { type: "null" }
+      ]
+    },
+    nextMatchNumber: { type: ["integer", "null"] },
+    winnerSlot: { type: ["integer", "null"] }
+  },
+  required: [
+    "matchNumber",
+    "round",
+    "player1Nickname",
+    "player2Nickname",
+    "player1Type",
+    "player2Type",
+    "winner",
+    "nextMatchNumber",
+    "winnerSlot"
+  ],
+  additionalProperties: false
 };
 
 export const tournamentSchema = {
@@ -40,18 +89,17 @@ export const tournamentSchema = {
     maxPlayers: {
       $ref: "tournamentDefinitionsSchema#/definitions/tournamentMaxPlayers"
     },
+    isPrivate: { type: "boolean" },
     isFinished: {
       $ref: "tournamentDefinitionsSchema#/definitions/tournamentIsFinished"
     },
     userId: { $ref: "commonDefinitionsSchema#/definitions/id" },
     userNickname: { $ref: "commonDefinitionsSchema#/definitions/username" },
-    bracket: {
-      $ref: "tournamentDefinitionsSchema#/definitions/tournamentBracket"
-    },
     roundReached: {
       $ref: "tournamentDefinitionsSchema#/definitions/tournamentRoundReached"
     },
-    updatedAt: { type: "string", format: "date-time" }
+    updatedAt: { type: "string", format: "date-time" },
+    bracket: { type: "array", items: { $ref: "bracketMatchSchema" } }
   },
   required: [
     "id",
@@ -60,7 +108,6 @@ export const tournamentSchema = {
     "isFinished",
     "userId",
     "userNickname",
-    "bracket",
     "roundReached"
   ],
   additionalProperties: false
@@ -109,11 +156,16 @@ const createTournamentSchema = {
       $ref: "tournamentDefinitionsSchema#/definitions/tournamentMaxPlayers"
     },
     userNickname: { $ref: "commonDefinitionsSchema#/definitions/username" },
-    bracket: {
-      $ref: "tournamentDefinitionsSchema#/definitions/tournamentBracket"
+    nicknames: {
+      type: "array",
+      items: { $ref: "commonDefinitionsSchema#/definitions/username" }
+    },
+    playerTypes: {
+      type: "array",
+      items: { $ref: "matchDefinitionsSchema#/definitions/playerType" }
     }
   },
-  required: ["name", "maxPlayers", "userNickname", "bracket"],
+  required: ["name", "maxPlayers", "userNickname", "nicknames", "playerTypes"],
   additionalProperties: false
 };
 
@@ -132,14 +184,11 @@ const patchTournamentSchema = {
     },
     {
       properties: {
-        bracket: {
-          $ref: "tournamentDefinitionsSchema#/definitions/tournamentBracket"
-        },
         roundReached: {
           $ref: "tournamentDefinitionsSchema#/definitions/tournamentRoundReached"
         }
       },
-      required: ["bracket", "roundReached"],
+      required: ["roundReached"],
       additionalProperties: false
     }
   ]
@@ -161,6 +210,7 @@ const querystringTournamentSchema = {
 
 export const tournamentSchemas = [
   tournamentDefinitionsSchema,
+  bracketMatchSchema,
   tournamentSchema,
   tournamentResponseSchema,
   tournamentArrayResponseSchema,

--- a/app/backend/src/schema/tournaments.schema.js
+++ b/app/backend/src/schema/tournaments.schema.js
@@ -170,26 +170,13 @@ const createTournamentSchema = {
 const patchTournamentSchema = {
   $id: "patchTournamentSchema",
   type: "object",
-  anyOf: [
-    {
-      properties: {
-        isFinished: {
-          $ref: "tournamentDefinitionsSchema#/definitions/tournamentIsFinished"
-        }
-      },
-      required: ["isFinished"],
-      additionalProperties: false
-    },
-    {
-      properties: {
-        roundReached: {
-          $ref: "tournamentDefinitionsSchema#/definitions/tournamentRoundReached"
-        }
-      },
-      required: ["roundReached"],
-      additionalProperties: false
+  properties: {
+    isFinished: {
+      $ref: "tournamentDefinitionsSchema#/definitions/tournamentIsFinished"
     }
-  ]
+  },
+  required: ["isFinished"],
+  additionalProperties: false
 };
 
 const patchTournamentMatchSchema = {

--- a/app/backend/src/services/bracket_match.services.js
+++ b/app/backend/src/services/bracket_match.services.js
@@ -1,0 +1,50 @@
+import prisma from "../prisma/prismaClient.js";
+
+export async function getBracketMatch(tournamentId, matchNumber) {
+  const bracketMatch = await prisma.bracketMatch.findUniqueOrThrow({
+    where: {
+      tournamentId_matchNumber: {
+        tournamentId,
+        matchNumber
+      }
+    }
+  });
+  return bracketMatch;
+}
+
+export async function updateBracketMatchTx(
+  tx,
+  tournamentId,
+  matchNumber,
+  updateData
+) {
+  const bracketMatch = await tx.bracketMatch.update({
+    where: {
+      tournamentId_matchNumber: {
+        tournamentId,
+        matchNumber
+      }
+    },
+    data: updateData
+  });
+  return bracketMatch;
+}
+
+export async function createBracketTx(tx, tournamentId, bracket) {
+  const bracketData = bracket.map((b) => ({
+    tournamentId: tournamentId,
+    matchNumber: b.matchNumber,
+    round: b.round,
+    player1Nickname: b.player1Nickname,
+    player2Nickname: b.player2Nickname,
+    player1Type: b.player1Type,
+    player2Type: b.player2Type,
+    winner: null,
+    nextMatchNumber: b.nextMatchNumber,
+    winnerSlot: b.winnerSlot
+  }));
+
+  await tx.bracketMatch.createMany({
+    data: bracketData
+  });
+}

--- a/app/backend/src/services/matches.services.js
+++ b/app/backend/src/services/matches.services.js
@@ -28,6 +28,7 @@ export async function createMatchTx(
   player1Type,
   player2Type,
   tournamentId,
+  bracketMatchNumber,
   date
 ) {
   const match = await tx.match.create({
@@ -41,6 +42,7 @@ export async function createMatchTx(
       player1Type,
       player2Type,
       tournamentId,
+      bracketMatchNumber,
       date
     },
     select: matchSelect

--- a/app/backend/src/services/matches.services.js
+++ b/app/backend/src/services/matches.services.js
@@ -27,7 +27,7 @@ export async function createMatchTx(
   player2Score,
   player1Type,
   player2Type,
-  tournament,
+  tournamentId,
   date
 ) {
   const match = await tx.match.create({
@@ -40,17 +40,17 @@ export async function createMatchTx(
       player2Score,
       player1Type,
       player2Type,
-      tournamentId: tournament?.id || null,
-      date: date
+      tournamentId,
+      date
     },
     select: matchSelect
   });
-  return match;
+  return flattenMatch(match);
 }
 
 export async function getAllMatches() {
   const matches = await prisma.match.findMany({ select: matchSelect });
-  return matches;
+  return matches.map(flattenMatch);
 }
 
 export async function getMatch(id) {
@@ -60,7 +60,7 @@ export async function getMatch(id) {
     },
     select: matchSelect
   });
-  return match;
+  return flattenMatch(match);
 }
 
 export async function getUserMatches(
@@ -79,7 +79,7 @@ export async function getUserMatches(
     skip: filter.offset,
     orderBy: { date: filter.sort || "desc" }
   });
-  return matches;
+  return matches.map(flattenMatch);
 }
 
 export async function deleteAllMatches() {
@@ -96,4 +96,12 @@ export async function getUserMatchesCount(userId, filter = {}) {
     }
   });
   return total;
+}
+
+function flattenMatch(rawMatch) {
+  const { tournament, ...rest } = rawMatch;
+  return {
+    ...rest,
+    tournamentName: tournament ? tournament.name : null
+  };
 }

--- a/app/backend/src/services/tournaments.services.js
+++ b/app/backend/src/services/tournaments.services.js
@@ -24,14 +24,15 @@ const tournamentSelect = {
   }
 };
 
-export async function createTournament(
+export async function createTournamentTx(
+  tx,
   name,
   maxPlayers,
   userId,
   userNickname,
   bracket
 ) {
-  const tournament = await prisma.tournament.create({
+  const tournament = await tx.tournament.create({
     data: {
       name,
       maxPlayers,

--- a/app/backend/src/services/tournaments.services.js
+++ b/app/backend/src/services/tournaments.services.js
@@ -6,7 +6,6 @@ const tournamentSelect = {
   name: true,
   maxPlayers: true,
   isFinished: true,
-  userId: true,
   userNickname: true,
   roundReached: true,
   updatedAt: true,
@@ -99,6 +98,7 @@ export async function getUserTournaments(
   const tournaments = await prisma.tournament.findMany({
     where: {
       userId: userId,
+      ...(filter.tournamentId ? { id: filter.tournamentId } : {}),
       ...(filter.isFinished !== undefined
         ? { isFinished: filter.isFinished }
         : {}),

--- a/app/backend/src/services/tournaments.services.js
+++ b/app/backend/src/services/tournaments.services.js
@@ -8,7 +8,20 @@ const tournamentSelect = {
   userId: true,
   userNickname: true,
   roundReached: true,
-  updatedAt: true
+  updatedAt: true,
+  bracket: {
+    select: {
+      matchNumber: true,
+      round: true,
+      player1Nickname: true,
+      player2Nickname: true,
+      player1Type: true,
+      player2Type: true,
+      winner: true,
+      nextMatchNumber: true,
+      winnerSlot: true
+    }
+  }
 };
 
 export async function createTournament(

--- a/app/backend/src/services/tournaments.services.js
+++ b/app/backend/src/services/tournaments.services.js
@@ -1,4 +1,5 @@
 import prisma from "../prisma/prismaClient.js";
+import { shuffle, unzip, zip } from "../utils/array.js";
 
 const tournamentSelect = {
   id: true,
@@ -129,6 +130,9 @@ export async function getUserTournamentsCount(userId, filter = {}) {
 }
 
 export function generateBracket(nicknames, playerTypes, numberOfPlayers) {
+  let combined = zip(nicknames, playerTypes);
+  combined = shuffle(combined);
+  const [shuffledNames, shuffledTypes] = unzip(combined);
   const totalRounds = Math.log2(numberOfPlayers);
   const bracket = [];
   let currentMatchId = 1;
@@ -156,23 +160,25 @@ export function generateBracket(nicknames, playerTypes, numberOfPlayers) {
     matchCount /= 2;
   }
 
+  const bracketMap = Object.fromEntries(bracket.map((m) => [m.matchNumber, m]));
+
   for (let r = 0; r < roundMatches.length - 1; r++) {
     const current = roundMatches[r];
     const next = roundMatches[r + 1];
     for (let i = 0; i < current.length; i++) {
-      const match = bracket.find((m) => m.matchNumber === current[i]);
+      const match = bracketMap[current[i]];
       match.nextMatchNumber = next[Math.floor(i / 2)];
       match.winnerSlot = i % 2 === 0 ? 1 : 2;
     }
   }
 
   const firstRound = roundMatches[0];
-  for (let i = 0; i < nicknames.length; i += 2) {
-    const match = bracket.find((m) => m.matchNumber === firstRound[i / 2]);
-    match.player1Nickname = nicknames[i];
-    match.player2Nickname = nicknames[i + 1];
-    match.player1Type = playerTypes[i] || "HUMAN";
-    match.player2Type = playerTypes[i + 1] || "HUMAN";
+  for (let i = 0; i < numberOfPlayers; i += 2) {
+    const match = bracketMap[firstRound[i / 2]];
+    match.player1Nickname = shuffledNames[i];
+    match.player2Nickname = shuffledNames[i + 1];
+    match.player1Type = shuffledTypes[i];
+    match.player2Type = shuffledTypes[i + 1];
   }
 
   return bracket;

--- a/app/backend/src/services/tournaments.services.js
+++ b/app/backend/src/services/tournaments.services.js
@@ -7,7 +7,6 @@ const tournamentSelect = {
   isFinished: true,
   userId: true,
   userNickname: true,
-  bracket: true,
   roundReached: true,
   updatedAt: true
 };
@@ -113,4 +112,54 @@ export async function getUserTournamentsCount(userId, filter = {}) {
     }
   });
   return total;
+}
+
+export function generateBracket(nicknames, playerTypes, numberOfPlayers) {
+  const totalRounds = Math.log2(numberOfPlayers);
+  const bracket = [];
+  let currentMatchId = 1;
+
+  const roundMatches = [];
+  let matchCount = numberOfPlayers / 2;
+
+  for (let round = 1; round <= totalRounds; round++) {
+    const matchIds = [];
+    for (let i = 0; i < matchCount; i++) {
+      bracket.push({
+        matchNumber: currentMatchId,
+        round: round,
+        player1Nickname: null,
+        player2Nickname: null,
+        player1Type: null,
+        player2Type: null,
+        winner: null,
+        nextMatchNumber: null,
+        winnerSlot: null
+      });
+      matchIds.push(currentMatchId++);
+    }
+    roundMatches.push(matchIds);
+    matchCount /= 2;
+  }
+
+  for (let r = 0; r < roundMatches.length - 1; r++) {
+    const current = roundMatches[r];
+    const next = roundMatches[r + 1];
+    for (let i = 0; i < current.length; i++) {
+      const match = bracket.find((m) => m.matchNumber === current[i]);
+      match.nextMatchNumber = next[Math.floor(i / 2)];
+      match.winnerSlot = i % 2 === 0 ? 1 : 2;
+    }
+  }
+
+  const firstRound = roundMatches[0];
+  for (let i = 0; i < nicknames.length; i += 2) {
+    const match = bracket.find((m) => m.matchNumber === firstRound[i / 2]);
+    match.player1Nickname = nicknames[i];
+    match.player2Nickname = nicknames[i + 1];
+    match.player1Type = playerTypes[i] || "HUMAN";
+    match.player2Type = playerTypes[i + 1] || "HUMAN";
+  }
+
+  return bracket;
 }

--- a/app/backend/src/services/transactions.services.js
+++ b/app/backend/src/services/transactions.services.js
@@ -86,6 +86,8 @@ export async function transactionTournament(
   nicknames,
   playertypes
 ) {
+  const bracket = generateBracket(nicknames, playertypes, maxPlayers);
+
   return prisma.$transaction(async (tx) => {
     const tournament = await createTournamentTx(
       tx,
@@ -94,8 +96,6 @@ export async function transactionTournament(
       userId,
       userNickname
     );
-
-    const bracket = generateBracket(nicknames, playertypes, maxPlayers);
 
     await createBracketTx(tx, tournament.id, bracket);
 

--- a/app/backend/src/services/transactions.services.js
+++ b/app/backend/src/services/transactions.services.js
@@ -135,8 +135,6 @@ export async function transactionUpdateBracket(
       { id: tournamentId },
       new Date()
     );
-    console.error(tournamentId);
-    console.dir(match);
 
     const currentBracketMatch = await updateBracketMatchTx(
       tx,
@@ -148,11 +146,16 @@ export async function transactionUpdateBracket(
     if (currentBracketMatch.nextMatchNumber && currentBracketMatch.winnerSlot) {
       const nextMatchNumber = currentBracketMatch.nextMatchNumber;
       const winnerSlot = currentBracketMatch.winnerSlot;
+      const winner = currentBracketMatch.winner;
+      const winnerPlayerType =
+        winner === currentBracketMatch.player1Nickname
+          ? currentBracketMatch.player1Type
+          : currentBracketMatch.player2Type;
 
       const updateData =
         winnerSlot === 1
-          ? { player1Nickname: bracketMatch.winner }
-          : { player2Nickname: bracketMatch.winner };
+          ? { player1Nickname: winner, player1Type: winnerPlayerType }
+          : { player2Nickname: winner, player2Type: winnerPlayerType };
 
       await updateBracketMatchTx(tx, tournamentId, nextMatchNumber, updateData);
     }

--- a/app/backend/src/services/transactions.services.js
+++ b/app/backend/src/services/transactions.services.js
@@ -18,6 +18,7 @@ async function createMatchAndUpdateStatsTx(
   player1Type,
   player2Type,
   tournamentId,
+  bracketMatchNumber,
   date
 ) {
   const match = await createMatchTx(
@@ -31,6 +32,7 @@ async function createMatchAndUpdateStatsTx(
     player1Type,
     player2Type,
     tournamentId,
+    bracketMatchNumber,
     date
   );
 
@@ -56,7 +58,6 @@ export async function transactionMatch(
   player2Score,
   player1Type,
   player2Type,
-  tournamentId,
   date
 ) {
   return prisma.$transaction(async (tx) => {
@@ -70,7 +71,8 @@ export async function transactionMatch(
       player2Score,
       player1Type,
       player2Type,
-      tournamentId,
+      null,
+      null,
       date
     );
 
@@ -175,6 +177,7 @@ export async function transactionUpdateBracket(
       player1Type,
       player2Type,
       tournamentId,
+      matchNumber,
       date
     );
 

--- a/app/backend/src/services/transactions.services.js
+++ b/app/backend/src/services/transactions.services.js
@@ -188,13 +188,20 @@ export async function transactionUpdateBracket(
       currentUpdate
     );
 
+    let nextBracketMatch = null;
     if (nextUpdate) {
-      await updateBracketMatchTx(tx, tournamentId, nextMatchNumber, nextUpdate);
+      nextBracketMatch = await updateBracketMatchTx(
+        tx,
+        tournamentId,
+        nextMatchNumber,
+        nextUpdate
+      );
     }
 
     return {
       match,
-      bracketMatch: currentBracketMatch
+      currentBracketMatch,
+      nextBracketMatch
     };
   });
 }

--- a/app/backend/src/services/transactions.services.js
+++ b/app/backend/src/services/transactions.services.js
@@ -17,7 +17,7 @@ async function createMatchAndUpdateStatsTx(
   player2Score,
   player1Type,
   player2Type,
-  tournament,
+  tournamentId,
   date
 ) {
   const match = await createMatchTx(
@@ -30,7 +30,7 @@ async function createMatchAndUpdateStatsTx(
     player2Score,
     player1Type,
     player2Type,
-    tournament,
+    tournamentId,
     date
   );
 
@@ -56,11 +56,11 @@ export async function transactionMatch(
   player2Score,
   player1Type,
   player2Type,
-  tournament,
+  tournamentId,
   date
 ) {
   return prisma.$transaction(async (tx) => {
-    const { match, stats } = createMatchAndUpdateStatsTx(
+    const { match, stats } = await createMatchAndUpdateStatsTx(
       tx,
       userId,
       playedAs,
@@ -70,7 +70,7 @@ export async function transactionMatch(
       player2Score,
       player1Type,
       player2Type,
-      tournament,
+      tournamentId,
       date
     );
 
@@ -132,7 +132,7 @@ export async function transactionUpdateBracket(
       player2Score,
       player1Type,
       player2Type,
-      { id: tournamentId },
+      tournamentId,
       new Date()
     );
 

--- a/app/backend/src/services/transactions.services.js
+++ b/app/backend/src/services/transactions.services.js
@@ -130,7 +130,8 @@ export async function transactionUpdateBracket(
   player1Score,
   player2Score,
   playedAs,
-  bracketMatch
+  bracketMatch,
+  date
 ) {
   const nextUpdate = buildBracketUpdates(bracketMatch);
 
@@ -156,7 +157,7 @@ export async function transactionUpdateBracket(
       player1Type,
       player2Type,
       tournamentId,
-      new Date()
+      date
     );
 
     const currentBracketMatch = await updateBracketMatchTx(

--- a/app/backend/src/services/transactions.services.js
+++ b/app/backend/src/services/transactions.services.js
@@ -1,5 +1,6 @@
 import prisma from "../prisma/prismaClient.js";
 import { createMatchTx } from "./matches.services.js";
+import { generateBracket } from "./tournaments.services.js";
 import { updateUserStatsTx } from "./user_stats.services.js";
 
 export async function transactionMatch(
@@ -40,5 +41,48 @@ export async function transactionMatch(
       );
     }
     return { match, stats };
+  });
+}
+
+export async function transactionTournament(
+  name,
+  maxPlayers,
+  userId,
+  userNickname,
+  nicknames,
+  playertypes
+) {
+  return prisma.$transaction(async (tx) => {
+    const tournament = await tx.tournament.create({
+      data: {
+        name,
+        maxPlayers,
+        userId,
+        userNickname
+      }
+    });
+
+    const bracket = generateBracket(nicknames, playertypes, maxPlayers);
+
+    const bracketData = bracket.map((b) => ({
+      tournamentId: tournament.id,
+      matchNumber: b.matchNumber,
+      round: b.round,
+      player1Nickname: b.player1Nickname,
+      player2Nickname: b.player2Nickname,
+      player1Type: b.player1Type,
+      player2Type: b.player2Type,
+      winner: null,
+      nextMatchNumber: b.nextMatchNumber,
+      winnerSlot: b.winnerSlot
+    }));
+
+    await tx.bracketMatch.createMany({
+      data: bracketData
+    });
+
+    tournament.bracket = bracket;
+
+    return tournament;
   });
 }

--- a/app/backend/src/utils/array.js
+++ b/app/backend/src/utils/array.js
@@ -1,0 +1,33 @@
+export function zip(a, b) {
+  const length = Math.min(a.length, b.length);
+  const result = [];
+  for (let i = 0; i < length; i++) {
+    result.push([a[i], b[i]]);
+  }
+  return result;
+}
+
+export function unzip(pairs) {
+  const a = [];
+  const b = [];
+  for (const [x, y] of pairs) {
+    a.push(x);
+    b.push(y);
+  }
+  return [a, b];
+}
+
+export function shuffle(array) {
+  let currentIndex = array.length;
+  while (currentIndex !== 0) {
+    const randomIndex = Math.floor(Math.random() * currentIndex);
+    currentIndex--;
+
+    // swap
+    [array[currentIndex], array[randomIndex]] = [
+      array[randomIndex],
+      array[currentIndex]
+    ];
+  }
+  return array;
+}

--- a/app/frontend/src/Tournament.ts
+++ b/app/frontend/src/Tournament.ts
@@ -1,33 +1,30 @@
-import type { TournamentDTO } from "./types/ITournament.ts";
-import type { BracketMatch } from "./types/ITournament.ts";
+import type { TournamentRead } from "./types/ITournament.ts";
 import type { BracketLayout } from "./types/BracketLayout.ts";
+import { BracketMatchRead } from "./types/BracketMatch.js";
 
 export class Tournament {
   private matchSlotMap: Record<
     number,
-    { slot1?: BracketMatch; slot2?: BracketMatch }
+    { slot1?: BracketMatchRead; slot2?: BracketMatchRead }
   > = {};
   private tournamentId: number;
   private tournamentName: string;
   private numberOfPlayers: number;
-  private userId: number;
   private userNickname: string;
   private roundReached: number;
-  private bracket: BracketMatch[];
+  private bracket: BracketMatchRead[];
 
   constructor({
     id,
     name,
     maxPlayers,
-    userId,
     userNickname,
     roundReached,
     bracket
-  }: TournamentDTO) {
+  }: TournamentRead) {
     this.tournamentId = id;
     this.tournamentName = name;
     this.numberOfPlayers = maxPlayers;
-    this.userId = userId;
     this.userNickname = userNickname;
     this.roundReached = roundReached;
     this.bracket = bracket;
@@ -63,7 +60,7 @@ export class Tournament {
     }
   }
 
-  public getNextMatchToPlay(): BracketMatch | null {
+  public getNextMatchToPlay(): BracketMatchRead | null {
     return (
       this.bracket
         .filter(
@@ -80,7 +77,7 @@ export class Tournament {
     );
   }
 
-  public getBracket(): BracketMatch[] {
+  public getBracket(): BracketMatchRead[] {
     return this.bracket;
   }
 
@@ -94,18 +91,6 @@ export class Tournament {
 
   public getRoundReached(): number {
     return this.roundReached;
-  }
-
-  public toJSON(): TournamentDTO {
-    return {
-      id: this.tournamentId,
-      name: this.tournamentName,
-      maxPlayers: this.numberOfPlayers,
-      userId: this.userId,
-      userNickname: this.userNickname,
-      roundReached: this.roundReached,
-      bracket: this.bracket
-    };
   }
 
   public static shuffle(array: string[], inPlace: boolean = true): string[] {

--- a/app/frontend/src/Tournament.ts
+++ b/app/frontend/src/Tournament.ts
@@ -40,6 +40,10 @@ export class Tournament {
     match.winner = winner;
 
     if (match.nextMatchNumber && match.winnerSlot) {
+      const playerType =
+        winner === match.player1Nickname
+          ? match.player1Type
+          : match.player2Type;
       const nextMatch = updated.find(
         (m) => m.matchNumber === match.nextMatchNumber
       );
@@ -47,8 +51,10 @@ export class Tournament {
 
       if (match.winnerSlot === 1) {
         nextMatch.player1Nickname = winner;
+        nextMatch.player1Type = playerType;
       } else {
         nextMatch.player2Nickname = winner;
+        nextMatch.player2Type = playerType;
       }
     }
 

--- a/app/frontend/src/Tournament.ts
+++ b/app/frontend/src/Tournament.ts
@@ -34,10 +34,10 @@ export class Tournament {
     this.buildMatchSlotMap();
   }
 
-  public updateBracketWithResult(matchId: number, winner: string): void {
+  public updateBracketWithResult(matchNumber: number, winner: string): void {
     const updated = this.bracket.map((m) => ({ ...m })); // clone
 
-    const match = updated.find((m) => m.matchNumber === matchId);
+    const match = updated.find((m) => m.matchNumber === matchNumber);
     if (!match) throw new Error(i18next.t("error.matchNotFound"));
 
     match.winner = winner;
@@ -282,10 +282,6 @@ export class Tournament {
     this.matchSlotMap = {};
 
     for (const match of this.bracket) {
-      console.log("Building slot map");
-      console.log(
-        `Next match Id: ${match.nextMatchNumber} , Winner Slot: ${match.winnerSlot}`
-      );
       if (!match.nextMatchNumber || !match.winnerSlot) {
         continue;
       }

--- a/app/frontend/src/Tournament.ts
+++ b/app/frontend/src/Tournament.ts
@@ -99,21 +99,6 @@ export class Tournament {
     return this.roundReached;
   }
 
-  public static shuffle(array: string[], inPlace: boolean = true): string[] {
-    // If we don't want to modify the original, copy it
-    const result = inPlace ? array : [...array];
-
-    for (let i = result.length - 1; i > 0; i--) {
-      // Pick a random index from 0 to i
-      const j = Math.floor(Math.random() * (i + 1));
-
-      // Swap elements result[i] and result[j]
-      [result[i], result[j]] = [result[j], result[i]];
-    }
-
-    return result;
-  }
-
   public getTournamentWinner(): string | null {
     const finalMatch = this.bracket.find((match) => !match.nextMatchNumber);
     return finalMatch?.winner ?? null;

--- a/app/frontend/src/Tournament.ts
+++ b/app/frontend/src/Tournament.ts
@@ -1,6 +1,6 @@
 import type { TournamentRead } from "./types/ITournament.ts";
 import type { BracketLayout } from "./types/BracketLayout.ts";
-import { BracketMatchRead } from "./types/BracketMatch.js";
+import type { BracketMatchRead } from "./types/BracketMatch.ts";
 
 export class Tournament {
   private matchSlotMap: Record<

--- a/app/frontend/src/components/MatchRow.ts
+++ b/app/frontend/src/components/MatchRow.ts
@@ -1,8 +1,8 @@
-import { Match, playedAs } from "../types/IMatch.js";
+import { MatchRead, PlayedAs } from "../types/IMatch.js";
 import { escapeHTML } from "../utility.js";
 
-export function MatchRow(match: Match, user: string): string {
-  const isPlayerOne = match.playedAs === playedAs.PLAYERONE;
+export function MatchRow(match: MatchRead, user: string): string {
+  const isPlayerOne = match.playedAs === PlayedAs.PLAYERONE;
 
   const result = isPlayerOne
     ? match.player1Score > match.player2Score
@@ -20,9 +20,9 @@ export function MatchRow(match: Match, user: string): string {
     ? match.player2Nickname
     : `${match.player2Nickname} (${user})`;
 
-  const tournamentDisplay = match.tournament?.name
+  const tournamentDisplay = match.tournamentName
     ? i18next.t("global.tournament", {
-        tournamentName: match.tournament.name
+        tournamentName: match.tournamentName
       })
     : "N/A";
 

--- a/app/frontend/src/components/MatchRow.ts
+++ b/app/frontend/src/components/MatchRow.ts
@@ -1,8 +1,8 @@
-import { MatchRead, PlayedAs } from "../types/IMatch.js";
+import { MatchRead } from "../types/IMatch.js";
 import { escapeHTML } from "../utility.js";
 
 export function MatchRow(match: MatchRead, user: string): string {
-  const isPlayerOne = match.playedAs === PlayedAs.PLAYERONE;
+  const isPlayerOne = match.playedAs === "PLAYERONE";
 
   const result = isPlayerOne
     ? match.player1Score > match.player2Score

--- a/app/frontend/src/components/TournamentRow.ts
+++ b/app/frontend/src/components/TournamentRow.ts
@@ -1,7 +1,7 @@
-import { TournamentDTO } from "../types/ITournament.js";
+import { TournamentRead } from "../types/ITournament.js";
 import { escapeHTML } from "../utility.js";
 
-export function TournamentRow(tournament: TournamentDTO): string {
+export function TournamentRow(tournament: TournamentRead): string {
   const result = didWinTournament(
     tournament.maxPlayers,
     tournament.roundReached

--- a/app/frontend/src/components/TournamentRow.ts
+++ b/app/frontend/src/components/TournamentRow.ts
@@ -39,5 +39,5 @@ export function NoTournamentsRow(): string {
 
 function didWinTournament(maxPlayers: number, roundReached: number): boolean {
   const totalRounds = Math.log2(maxPlayers);
-  return roundReached === totalRounds;
+  return roundReached === totalRounds + 1;
 }

--- a/app/frontend/src/game.ts
+++ b/app/frontend/src/game.ts
@@ -167,29 +167,34 @@ async function endGame(
   userRole: playedAs
 ) {
   if (tournament) {
-    const matchId = tournament.getNextMatchToPlay()!.matchNumber;
+    const matchNumber = tournament.getNextMatchToPlay()!.matchNumber;
     const winner =
       gameState.player1Score > gameState.player2Score
         ? gameState.player1
         : gameState.player2;
-    tournament.updateBracketWithResult(matchId, winner);
-    getDataOrThrow(await updateTournamentBracket(tournament));
+    tournament.updateBracketWithResult(matchNumber, winner);
+    getDataOrThrow(
+      await updateTournamentBracket(
+        tournament.getId(),
+        matchNumber,
+        gameState.player1Score,
+        gameState.player2Score
+      )
+    );
+  } else {
+    getDataOrThrow(
+      await createMatch({
+        playedAs: userRole,
+        player1Nickname: gameState.player1,
+        player2Nickname: gameState.player2,
+        player1Score: gameState.player1Score,
+        player2Score: gameState.player2Score,
+        player1Type: gameState.aiPlayer1 ? "AI" : "HUMAN",
+        player2Type: gameState.aiPlayer2 ? "AI" : "HUMAN",
+        tournament: null
+      })
+    );
   }
-
-  getDataOrThrow(
-    await createMatch({
-      playedAs: userRole,
-      player1Nickname: gameState.player1,
-      player2Nickname: gameState.player2,
-      player1Score: gameState.player1Score,
-      player2Score: gameState.player2Score,
-      player1Type: gameState.aiPlayer1 ? "AI" : "HUMAN",
-      player2Type: gameState.aiPlayer2 ? "AI" : "HUMAN",
-      tournament: tournament
-        ? { id: tournament!.getId(), name: tournament!.getTournamentName() }
-        : null
-    })
-  );
 
   await waitForEnterKey();
 }

--- a/app/frontend/src/game.ts
+++ b/app/frontend/src/game.ts
@@ -191,8 +191,7 @@ async function endGame(
         player1Score: gameState.player1Score,
         player2Score: gameState.player2Score,
         player1Type: gameState.aiPlayer1 ? "AI" : "HUMAN",
-        player2Type: gameState.aiPlayer2 ? "AI" : "HUMAN",
-        tournamentId: null
+        player2Type: gameState.aiPlayer2 ? "AI" : "HUMAN"
       })
     );
   }

--- a/app/frontend/src/game.ts
+++ b/app/frontend/src/game.ts
@@ -5,7 +5,7 @@ import { GameKey } from "./views/GameView.js";
 import { Tournament } from "./Tournament.js";
 import { updateTournamentBracket } from "./services/tournamentService.js";
 import { createMatch } from "./services/matchServices.js";
-import { playedAs, PlayerType } from "./types/IMatch.js";
+import { PlayedAs, PlayerType } from "./types/IMatch.js";
 import { getDataOrThrow } from "./services/api.js";
 import { AIPlayer } from "./AIPlayer.js";
 
@@ -24,7 +24,7 @@ export async function startGame(
   nickname2: string,
   type1: PlayerType,
   type2: PlayerType,
-  userRole: playedAs,
+  userRole: PlayedAs,
   tournament: Tournament | null,
   keys: Record<GameKey, boolean>
 ) {
@@ -164,7 +164,7 @@ function checkWinner(gameState: GameState) {
 async function endGame(
   gameState: GameState,
   tournament: Tournament | null,
-  userRole: playedAs
+  userRole: PlayedAs
 ) {
   if (tournament) {
     const matchNumber = tournament.getNextMatchToPlay()!.matchNumber;
@@ -191,7 +191,7 @@ async function endGame(
         player2Score: gameState.player2Score,
         player1Type: gameState.aiPlayer1 ? "AI" : "HUMAN",
         player2Type: gameState.aiPlayer2 ? "AI" : "HUMAN",
-        tournament: null
+        tournamentId: null
       })
     );
   }

--- a/app/frontend/src/game.ts
+++ b/app/frontend/src/game.ts
@@ -167,7 +167,7 @@ async function endGame(
   userRole: playedAs
 ) {
   if (tournament) {
-    const matchId = tournament.getNextMatchToPlay()!.matchId;
+    const matchId = tournament.getNextMatchToPlay()!.matchNumber;
     const winner =
       gameState.player1Score > gameState.player2Score
         ? gameState.player1

--- a/app/frontend/src/game.ts
+++ b/app/frontend/src/game.ts
@@ -175,12 +175,12 @@ async function endGame(
         : gameState.player2;
     tournament.updateBracketWithResult(matchNumber, winner);
     getDataOrThrow(
-      await updateTournamentBracket(
-        tournament.getId(),
+      await updateTournamentBracket({
+        tournamentId: tournament.getId(),
         matchNumber,
-        gameState.player1Score,
-        gameState.player2Score
-      )
+        player1Score: gameState.player1Score,
+        player2Score: gameState.player2Score
+      })
     );
   } else {
     getDataOrThrow(

--- a/app/frontend/src/services/matchServices.ts
+++ b/app/frontend/src/services/matchServices.ts
@@ -1,11 +1,13 @@
 import { apiFetch } from "./api.js";
-import { Match } from "../types/IMatch.js";
+import { MatchCreate, MatchRead } from "../types/IMatch.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 
-export async function createMatch(match: Match): Promise<ApiResponse<Match>> {
+export async function createMatch(
+  match: MatchCreate
+): Promise<ApiResponse<MatchRead>> {
   const url = "/api/matches";
 
-  return apiFetch<Match>(url, {
+  return apiFetch<MatchRead>(url, {
     method: "POST",
     body: JSON.stringify(match),
     credentials: "same-origin"

--- a/app/frontend/src/services/tournamentService.ts
+++ b/app/frontend/src/services/tournamentService.ts
@@ -6,7 +6,7 @@ import {
 import { apiFetch } from "./api.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 import { FetchPageResult } from "../types/FetchPageResult.js";
-import { Match } from "../types/IMatch.js";
+import { MatchRead } from "../types/IMatch.js";
 
 export async function createTournament(
   tournament: CreateTournamentParams
@@ -35,10 +35,10 @@ export async function updateTournamentBracket(
   matchNumber: number,
   player1Score: number,
   player2Score: number
-): Promise<ApiResponse<{ match: Match; bracketMatch: BracketMatch }>> {
+): Promise<ApiResponse<{ match: MatchRead; bracketMatch: BracketMatch }>> {
   const url = `/api/tournaments/${tournamentId}/matches/${matchNumber}`;
 
-  return apiFetch<{ match: Match; bracketMatch: BracketMatch }>(url, {
+  return apiFetch<{ match: MatchRead; bracketMatch: BracketMatch }>(url, {
     method: "PATCH",
     body: JSON.stringify({ player1Score, player2Score })
   });

--- a/app/frontend/src/services/tournamentService.ts
+++ b/app/frontend/src/services/tournamentService.ts
@@ -3,7 +3,7 @@ import { apiFetch } from "./api.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 import { FetchPageResult } from "../types/FetchPageResult.js";
 import { MatchRead } from "../types/IMatch.js";
-import { BracketMatchRead } from "../types/BracketMatch.js";
+import { BracketMatchRead, BracketMatchUpdate } from "../types/BracketMatch.js";
 
 export async function createTournament(
   tournament: TournamentCreate
@@ -28,11 +28,11 @@ export async function setTournamentFinished(
 }
 
 export async function updateTournamentBracket(
-  tournamentId: number,
-  matchNumber: number,
-  player1Score: number,
-  player2Score: number
+  bracketMatchUpdate: BracketMatchUpdate
 ): Promise<ApiResponse<{ match: MatchRead; bracketMatch: BracketMatchRead }>> {
+  const { tournamentId, matchNumber, player1Score, player2Score } =
+    bracketMatchUpdate;
+
   const url = `/api/tournaments/${tournamentId}/matches/${matchNumber}`;
 
   return apiFetch<{ match: MatchRead; bracketMatch: BracketMatchRead }>(url, {

--- a/app/frontend/src/services/tournamentService.ts
+++ b/app/frontend/src/services/tournamentService.ts
@@ -1,8 +1,12 @@
-import { Tournament } from "../Tournament.js";
-import { CreateTournamentParams, TournamentDTO } from "../types/ITournament.js";
+import {
+  BracketMatch,
+  CreateTournamentParams,
+  TournamentDTO
+} from "../types/ITournament.js";
 import { apiFetch } from "./api.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 import { FetchPageResult } from "../types/FetchPageResult.js";
+import { Match } from "../types/IMatch.js";
 
 export async function createTournament(
   tournament: CreateTournamentParams
@@ -27,17 +31,16 @@ export async function setTournamentFinished(
 }
 
 export async function updateTournamentBracket(
-  tournament: Tournament
-): Promise<ApiResponse<TournamentDTO>> {
-  const tournamentId = tournament.getId();
-  const url = `/api/tournaments/${tournamentId}`;
+  tournamentId: number,
+  matchNumber: number,
+  player1Score: number,
+  player2Score: number
+): Promise<ApiResponse<{ match: Match; bracketMatch: BracketMatch }>> {
+  const url = `/api/tournaments/${tournamentId}/matches/${matchNumber}`;
 
-  return apiFetch<TournamentDTO>(url, {
+  return apiFetch<{ match: Match; bracketMatch: BracketMatch }>(url, {
     method: "PATCH",
-    body: JSON.stringify({
-      bracket: JSON.stringify(tournament.getBracket()),
-      roundReached: tournament.getRoundReached()
-    })
+    body: JSON.stringify({ player1Score, player2Score })
   });
 }
 

--- a/app/frontend/src/services/tournamentService.ts
+++ b/app/frontend/src/services/tournamentService.ts
@@ -1,17 +1,17 @@
 import { Tournament } from "../Tournament.js";
-import { TournamentDTO } from "../types/ITournament.js";
+import { CreateTournamentParams, TournamentDTO } from "../types/ITournament.js";
 import { apiFetch } from "./api.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 import { FetchPageResult } from "../types/FetchPageResult.js";
 
 export async function createTournament(
-  tournament: Tournament
+  tournament: CreateTournamentParams
 ): Promise<ApiResponse<TournamentDTO>> {
   const url = "/api/tournaments";
 
   return apiFetch<TournamentDTO>(url, {
     method: "POST",
-    body: JSON.stringify(tournament) // uses toJSON()
+    body: JSON.stringify(tournament)
   });
 }
 

--- a/app/frontend/src/services/tournamentService.ts
+++ b/app/frontend/src/services/tournamentService.ts
@@ -1,19 +1,16 @@
-import {
-  BracketMatch,
-  CreateTournamentParams,
-  TournamentDTO
-} from "../types/ITournament.js";
+import { TournamentCreate, TournamentRead } from "../types/ITournament.js";
 import { apiFetch } from "./api.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 import { FetchPageResult } from "../types/FetchPageResult.js";
 import { MatchRead } from "../types/IMatch.js";
+import { BracketMatchRead } from "../types/BracketMatch.js";
 
 export async function createTournament(
-  tournament: CreateTournamentParams
-): Promise<ApiResponse<TournamentDTO>> {
+  tournament: TournamentCreate
+): Promise<ApiResponse<TournamentRead>> {
   const url = "/api/tournaments";
 
-  return apiFetch<TournamentDTO>(url, {
+  return apiFetch<TournamentRead>(url, {
     method: "POST",
     body: JSON.stringify(tournament)
   });
@@ -21,10 +18,10 @@ export async function createTournament(
 
 export async function setTournamentFinished(
   tournamentId: number
-): Promise<ApiResponse<TournamentDTO>> {
+): Promise<ApiResponse<TournamentRead>> {
   const url = `/api/tournaments/${tournamentId}`;
 
-  return apiFetch<TournamentDTO>(url, {
+  return apiFetch<TournamentRead>(url, {
     method: "PATCH",
     body: JSON.stringify({ isFinished: true })
   });
@@ -35,10 +32,10 @@ export async function updateTournamentBracket(
   matchNumber: number,
   player1Score: number,
   player2Score: number
-): Promise<ApiResponse<{ match: MatchRead; bracketMatch: BracketMatch }>> {
+): Promise<ApiResponse<{ match: MatchRead; bracketMatch: BracketMatchRead }>> {
   const url = `/api/tournaments/${tournamentId}/matches/${matchNumber}`;
 
-  return apiFetch<{ match: MatchRead; bracketMatch: BracketMatch }>(url, {
+  return apiFetch<{ match: MatchRead; bracketMatch: BracketMatchRead }>(url, {
     method: "PATCH",
     body: JSON.stringify({ player1Score, player2Score })
   });
@@ -51,7 +48,7 @@ export async function getUserTournaments(options: {
   limit?: number;
   offset?: number;
   sort?: "asc" | "desc";
-}): Promise<ApiResponse<FetchPageResult<TournamentDTO>>> {
+}): Promise<ApiResponse<FetchPageResult<TournamentRead>>> {
   const { username, name, isFinished, limit, offset, sort = "desc" } = options;
   const encoded = encodeURIComponent(username);
   let url = `/api/users/${encoded}/tournaments`;
@@ -76,10 +73,10 @@ export async function getUserTournaments(options: {
 
 export async function deleteTournament(
   id: number
-): Promise<ApiResponse<TournamentDTO>> {
+): Promise<ApiResponse<TournamentRead>> {
   const url = `/api/tournaments/${id}`;
 
-  return apiFetch<TournamentDTO>(url, {
+  return apiFetch<TournamentRead>(url, {
     method: "DELETE"
   });
 }

--- a/app/frontend/src/services/userServices.ts
+++ b/app/frontend/src/services/userServices.ts
@@ -2,7 +2,7 @@ import { apiFetch } from "./api.js";
 import { User } from "../types/User.js";
 import { ApiResponse } from "../types/IApiResponse.js";
 import { FetchPageResult } from "../types/FetchPageResult.js";
-import { Match } from "../types/IMatch.js";
+import { MatchRead } from "../types/IMatch.js";
 
 export async function getUserProfile(): Promise<ApiResponse<User>> {
   const url = "/api/users/me";
@@ -86,7 +86,7 @@ export async function getUserPlayedMatchesByUsername(
   limit = 10,
   offset = 0,
   sort: "asc" | "desc" = "desc"
-): Promise<ApiResponse<FetchPageResult<Match>>> {
+): Promise<ApiResponse<FetchPageResult<MatchRead>>> {
   const encoded = encodeURIComponent(username);
   const params = new URLSearchParams();
   params.set("limit", limit.toString());
@@ -97,7 +97,7 @@ export async function getUserPlayedMatchesByUsername(
 
   const url = `/api/users/${encoded}/matches?${params.toString()}`;
 
-  return apiFetch<FetchPageResult<Match>>(url, {
+  return apiFetch<FetchPageResult<MatchRead>>(url, {
     method: "GET",
     credentials: "same-origin"
   });

--- a/app/frontend/src/types/BracketMatch.ts
+++ b/app/frontend/src/types/BracketMatch.ts
@@ -1,0 +1,3 @@
+import type { BracketMatch as BracketMatchDB } from "@prisma/client";
+
+export type BracketMatchRead = Omit<BracketMatchDB, "tournamentId">;

--- a/app/frontend/src/types/BracketMatch.ts
+++ b/app/frontend/src/types/BracketMatch.ts
@@ -1,3 +1,11 @@
 import type { BracketMatch as BracketMatchDB } from "@prisma/client";
+import { Simplify } from "./Simplify";
 
 export type BracketMatchRead = Omit<BracketMatchDB, "tournamentId">;
+
+export type BracketMatchUpdate = Simplify<
+  Pick<BracketMatchDB, "tournamentId" | "matchNumber"> & {
+    player1Score: number;
+    player2Score: number;
+  }
+>;

--- a/app/frontend/src/types/IMatch.ts
+++ b/app/frontend/src/types/IMatch.ts
@@ -5,7 +5,7 @@ export { PlayedAs, PlayerType };
 
 export type MatchCreate = Omit<
   MatchDB,
-  "id" | "userId" | "date" | "bracketMatchNumber"
+  "id" | "userId" | "date" | "bracketMatchNumber" | "tournamentId"
 >;
 
 export type MatchRead = Simplify<

--- a/app/frontend/src/types/IMatch.ts
+++ b/app/frontend/src/types/IMatch.ts
@@ -1,4 +1,4 @@
-import { Match as MatchDB, PlayedAs, PlayerType } from "@prisma/client";
+import type { Match as MatchDB, PlayedAs, PlayerType } from "@prisma/client";
 import { Simplify } from "./Simplify";
 
 export { PlayedAs, PlayerType };

--- a/app/frontend/src/types/IMatch.ts
+++ b/app/frontend/src/types/IMatch.ts
@@ -1,22 +1,15 @@
-export enum playedAs {
-  NONE = "NONE",
-  PLAYERONE = "PLAYERONE",
-  PLAYERTWO = "PLAYERTWO"
-}
+import { Match as MatchDB, PlayedAs, PlayerType } from "@prisma/client";
+import { Simplify } from "./Simplify";
 
-export type PlayerType = "HUMAN" | "AI";
+export { PlayedAs, PlayerType };
 
-export interface Match {
-  playedAs: playedAs;
-  player1Nickname: string;
-  player2Nickname: string;
-  player1Score: number;
-  player2Score: number;
-  player1Type: PlayerType;
-  player2Type: PlayerType;
-  tournament?: {
-    id: number;
-    name: string;
-  } | null;
-  date?: string;
-}
+export type MatchCreate = Omit<
+  MatchDB,
+  "id" | "userId" | "date" | "bracketMatchNumber"
+>;
+
+export type MatchRead = Simplify<
+  Omit<MatchDB, "id" | "userId" | "tournamentId" | "bracketMatchNumber"> & {
+    tournamentName: string | null;
+  }
+>;

--- a/app/frontend/src/types/IMatch.ts
+++ b/app/frontend/src/types/IMatch.ts
@@ -20,13 +20,3 @@ export interface Match {
   } | null;
   date?: string;
 }
-
-export type BracketMatch = {
-  matchId: number;
-  round: number;
-  player1: string | null;
-  player2: string | null;
-  winner: string | null;
-  nextMatchId?: number;
-  winnerSlot?: 1 | 2;
-};

--- a/app/frontend/src/types/ITournament.ts
+++ b/app/frontend/src/types/ITournament.ts
@@ -1,11 +1,33 @@
+import { PlayerType } from "./IMatch";
+
 export type TournamentSize = 4 | 8 | 16;
 
 export interface TournamentDTO {
-  id?: number;
+  id: number;
   name: string;
   maxPlayers: number;
   userId: number;
   userNickname: string;
   roundReached: number;
-  bracket: string;
+  bracket: BracketMatch[];
 }
+
+export type BracketMatch = {
+  matchNumber: number;
+  round: number;
+  player1Nickname: string | null;
+  player2Nickname: string | null;
+  player1Type: PlayerType | null;
+  player2Type: PlayerType | null;
+  winner: string | null;
+  nextMatchNumber: number | null;
+  winnerSlot: 1 | 2 | null;
+};
+
+export type CreateTournamentParams = {
+  name: string;
+  maxPlayers: TournamentSize;
+  userNickname: string;
+  nicknames: string[];
+  playerTypes: PlayerType[];
+};

--- a/app/frontend/src/types/ITournament.ts
+++ b/app/frontend/src/types/ITournament.ts
@@ -1,33 +1,22 @@
-import { PlayerType } from "./IMatch";
+import type { Tournament as TournamentDB } from "@prisma/client";
+import type { PlayerType } from "./IMatch";
+import type { Simplify } from "./Simplify";
+import type { BracketMatchRead } from "./BracketMatch";
 
 export type TournamentSize = 4 | 8 | 16;
 
-export interface TournamentDTO {
-  id: number;
-  name: string;
-  maxPlayers: number;
-  userId: number;
-  userNickname: string;
-  roundReached: number;
-  bracket: BracketMatch[];
-}
+export type TournamentCreate = Simplify<
+  Omit<
+    TournamentDB,
+    "id" | "isPrivate" | "isFinished" | "userId" | "roundReached" | "updatedAt"
+  > & {
+    nicknames: string[];
+    playerTypes: PlayerType[];
+  }
+>;
 
-export type BracketMatch = {
-  matchNumber: number;
-  round: number;
-  player1Nickname: string | null;
-  player2Nickname: string | null;
-  player1Type: PlayerType | null;
-  player2Type: PlayerType | null;
-  winner: string | null;
-  nextMatchNumber: number | null;
-  winnerSlot: 1 | 2 | null;
-};
-
-export type CreateTournamentParams = {
-  name: string;
-  maxPlayers: TournamentSize;
-  userNickname: string;
-  nicknames: string[];
-  playerTypes: PlayerType[];
-};
+export type TournamentRead = Simplify<
+  Omit<TournamentDB, "isPrivate" | "userId"> & {
+    bracket: BracketMatchRead[];
+  }
+>;

--- a/app/frontend/src/types/Simplify.ts
+++ b/app/frontend/src/types/Simplify.ts
@@ -1,0 +1,1 @@
+export type Simplify<T> = { [K in keyof T]: T[K] } & {};

--- a/app/frontend/src/views/GameView.ts
+++ b/app/frontend/src/views/GameView.ts
@@ -5,7 +5,7 @@ import MatchAnnouncement from "./MatchAnnouncementView.js";
 import ResultsView from "./ResultsView.js";
 import NewGameView from "./NewGameView.js";
 import { Tournament } from "../Tournament.js";
-import { playedAs, PlayerType } from "../types/IMatch.js";
+import { PlayedAs, PlayerType } from "../types/IMatch.js";
 
 export type GameKey = "w" | "s" | "ArrowUp" | "ArrowDown";
 
@@ -28,7 +28,7 @@ export class GameView extends AbstractView {
     private nickname2: string,
     private type1: PlayerType,
     private type2: PlayerType,
-    private userRole: playedAs,
+    private userRole: PlayedAs,
     private gameType: GameType,
     private tournament: Tournament | null
   ) {

--- a/app/frontend/src/views/MatchAnnouncementView.ts
+++ b/app/frontend/src/views/MatchAnnouncementView.ts
@@ -8,7 +8,7 @@ import { Header1 } from "../components/Header1.js";
 import { Paragraph } from "../components/Paragraph.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
-import { playedAs } from "../types/IMatch.js";
+import { PlayedAs } from "../types/IMatch.js";
 import { getDataOrThrow } from "../services/api.js";
 
 export default class MatchAnnouncementView extends AbstractView {
@@ -16,7 +16,7 @@ export default class MatchAnnouncementView extends AbstractView {
   private player2: string;
   private matchNumber: number;
   private roundNumber: number;
-  private userRole: playedAs;
+  private userRole: PlayedAs;
 
   constructor(private tournament: Tournament) {
     super();
@@ -32,10 +32,10 @@ export default class MatchAnnouncementView extends AbstractView {
     const userNickname = tournament.getUserNickname();
     this.userRole =
       this.player1 === userNickname
-        ? playedAs.PLAYERONE
+        ? PlayedAs.PLAYERONE
         : this.player2 === userNickname
-          ? playedAs.PLAYERTWO
-          : playedAs.NONE;
+          ? PlayedAs.PLAYERTWO
+          : PlayedAs.NONE;
   }
 
   createHTML() {

--- a/app/frontend/src/views/MatchAnnouncementView.ts
+++ b/app/frontend/src/views/MatchAnnouncementView.ts
@@ -25,9 +25,9 @@ export default class MatchAnnouncementView extends AbstractView {
     if (!match) {
       throw new Error(i18next.t("error.undefinedMatch"));
     }
-    this.player1 = match.player1!;
-    this.player2 = match.player2!;
-    this.matchNumber = match.matchId;
+    this.player1 = match.player1Nickname!;
+    this.player2 = match.player2Nickname!;
+    this.matchNumber = match.matchNumber;
     this.roundNumber = match.round;
     const userNickname = tournament.getUserNickname();
     this.userRole =

--- a/app/frontend/src/views/MatchAnnouncementView.ts
+++ b/app/frontend/src/views/MatchAnnouncementView.ts
@@ -32,10 +32,10 @@ export default class MatchAnnouncementView extends AbstractView {
     const userNickname = tournament.getUserNickname();
     this.userRole =
       this.player1 === userNickname
-        ? PlayedAs.PLAYERONE
+        ? "PLAYERONE"
         : this.player2 === userNickname
-          ? PlayedAs.PLAYERTWO
-          : PlayedAs.NONE;
+          ? "PLAYERTWO"
+          : "NONE";
   }
 
   createHTML() {

--- a/app/frontend/src/views/MatchAnnouncementView.ts
+++ b/app/frontend/src/views/MatchAnnouncementView.ts
@@ -8,12 +8,14 @@ import { Header1 } from "../components/Header1.js";
 import { Paragraph } from "../components/Paragraph.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
-import { PlayedAs } from "../types/IMatch.js";
+import { PlayedAs, PlayerType } from "../types/IMatch.js";
 import { getDataOrThrow } from "../services/api.js";
 
 export default class MatchAnnouncementView extends AbstractView {
   private player1: string;
   private player2: string;
+  private player1type: PlayerType;
+  private player2type: PlayerType;
   private matchNumber: number;
   private roundNumber: number;
   private userRole: PlayedAs;
@@ -27,6 +29,8 @@ export default class MatchAnnouncementView extends AbstractView {
     }
     this.player1 = match.player1Nickname!;
     this.player2 = match.player2Nickname!;
+    this.player1type = match.player1Type!;
+    this.player2type = match.player2Type!;
     this.matchNumber = match.matchNumber;
     this.roundNumber = match.round;
     const userNickname = tournament.getUserNickname();
@@ -112,8 +116,8 @@ export default class MatchAnnouncementView extends AbstractView {
     const gameView = new GameView(
       this.player1,
       this.player2,
-      "HUMAN",
-      "HUMAN",
+      this.player1type,
+      this.player2type,
       this.userRole,
       GameType.tournament,
       this.tournament

--- a/app/frontend/src/views/NewGameView.ts
+++ b/app/frontend/src/views/NewGameView.ts
@@ -11,7 +11,6 @@ import { Paragraph } from "../components/Paragraph.js";
 import { escapeHTML } from "../utility.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
-import { PlayedAs } from "../types/IMatch.js";
 
 export default class NewGameView extends AbstractView {
   private formEl!: HTMLFormElement;
@@ -79,7 +78,7 @@ export default class NewGameView extends AbstractView {
       nicknames[1],
       player1type,
       player2type,
-      userNumber == "1" ? PlayedAs.PLAYERONE : PlayedAs.PLAYERTWO,
+      userNumber == "1" ? "PLAYERONE" : "PLAYERTWO",
       GameType.single,
       null
     );

--- a/app/frontend/src/views/NewGameView.ts
+++ b/app/frontend/src/views/NewGameView.ts
@@ -11,7 +11,7 @@ import { Paragraph } from "../components/Paragraph.js";
 import { escapeHTML } from "../utility.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
-import { playedAs } from "../types/IMatch.js";
+import { PlayedAs } from "../types/IMatch.js";
 
 export default class NewGameView extends AbstractView {
   private formEl!: HTMLFormElement;
@@ -79,7 +79,7 @@ export default class NewGameView extends AbstractView {
       nicknames[1],
       player1type,
       player2type,
-      userNumber == "1" ? playedAs.PLAYERONE : playedAs.PLAYERTWO,
+      userNumber == "1" ? PlayedAs.PLAYERONE : PlayedAs.PLAYERTWO,
       GameType.single,
       null
     );

--- a/app/frontend/src/views/NewTournamentView.ts
+++ b/app/frontend/src/views/NewTournamentView.ts
@@ -1,7 +1,6 @@
 import { router } from "../routing/Router.js";
 import { getUserTournaments } from "../services/tournamentService.js";
 import { Tournament } from "../Tournament.js";
-import { BracketMatch } from "../types/IMatch.js";
 import AbstractView from "./AbstractView.js";
 import MatchAnnouncement from "./MatchAnnouncementView.js";
 import PlayerNicknames from "./PlayerNicknamesView.js";
@@ -104,16 +103,7 @@ export default class NewTournamentView extends AbstractView {
       return;
     }
     const activeTournament = tournamentsPage.items[0];
-    const bracket = JSON.parse(activeTournament.bracket) as BracketMatch[];
-    const tournament = new Tournament(
-      activeTournament.name,
-      activeTournament.maxPlayers,
-      activeTournament.userId,
-      activeTournament.userNickname,
-      activeTournament.roundReached,
-      bracket,
-      activeTournament.id
-    );
+    const tournament = new Tournament(activeTournament);
     if (tournament.getNextMatchToPlay()) {
       router.switchView(new MatchAnnouncement(tournament));
     } else {

--- a/app/frontend/src/views/PlayerNicknamesView.ts
+++ b/app/frontend/src/views/PlayerNicknamesView.ts
@@ -13,6 +13,7 @@ import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
 import { getDataOrThrow } from "../services/api.js";
 import { TournamentSize } from "../types/ITournament.js";
+import { PlayerType } from "@prisma/client";
 
 export default class PlayerNicknamesView extends AbstractView {
   private formEl!: HTMLFormElement;
@@ -85,6 +86,12 @@ export default class PlayerNicknamesView extends AbstractView {
     const userNickname = formData.get(`player-${userNumber}`) as string;
     console.log(userNickname);
 
+    const playerTypes: PlayerType[] = [];
+    for (let i = 1; i <= this.numberOfPlayers; i++) {
+      const isAi = formData.has(`ai-player-${i}`);
+      playerTypes.push(isAi ? "AI" : "HUMAN");
+    }
+
     try {
       const createdTournament = getDataOrThrow(
         await createTournament({
@@ -92,7 +99,7 @@ export default class PlayerNicknamesView extends AbstractView {
           maxPlayers: this.numberOfPlayers as TournamentSize,
           userNickname: userNickname,
           nicknames: nicknames,
-          playerTypes: Array(this.numberOfPlayers).fill("HUMAN")
+          playerTypes: playerTypes
         })
       );
       const tournament = new Tournament(createdTournament);

--- a/app/frontend/src/views/PlayerNicknamesView.ts
+++ b/app/frontend/src/views/PlayerNicknamesView.ts
@@ -12,6 +12,7 @@ import { Paragraph } from "../components/Paragraph.js";
 import { Button } from "../components/Button.js";
 import { Form } from "../components/Form.js";
 import { getDataOrThrow } from "../services/api.js";
+import { TournamentSize } from "../types/ITournament.js";
 
 export default class PlayerNicknamesView extends AbstractView {
   private formEl!: HTMLFormElement;
@@ -85,22 +86,17 @@ export default class PlayerNicknamesView extends AbstractView {
     console.log(userNickname);
 
     try {
-      const userId = auth.getToken().id;
-      const tournament = Tournament.fromUsernames(
-        nicknames,
-        this.tournamentName,
-        this.numberOfPlayers,
-        userNickname,
-        userId
-      );
-
       const createdTournament = getDataOrThrow(
-        await createTournament(tournament)
+        await createTournament({
+          name: this.tournamentName,
+          maxPlayers: this.numberOfPlayers as TournamentSize,
+          userNickname: userNickname,
+          nicknames: nicknames,
+          playerTypes: Array(this.numberOfPlayers).fill("HUMAN")
+        })
       );
-      const { id } = createdTournament;
-      if (id) {
-        tournament.setId(id);
-      }
+      const tournament = new Tournament(createdTournament);
+
       const matchAnnouncementView = new MatchAnnouncement(tournament);
       router.switchView(matchAnnouncementView);
     } catch (error) {

--- a/app/frontend/src/views/tabs/MatchesTab.ts
+++ b/app/frontend/src/views/tabs/MatchesTab.ts
@@ -11,11 +11,11 @@ import { getDataOrThrow } from "../../services/api.js";
 import { getUserPlayedMatchesByUsername } from "../../services/userServices.js";
 import { getUserDashboardMatchesByUsername } from "../../services/userStatsServices.js";
 import { DashboardMatches } from "../../types/DataSeries.js";
-import { Match } from "../../types/IMatch.js";
+import { MatchRead } from "../../types/IMatch.js";
 import { UserStats } from "../../types/IUserStats.js";
 import { PaginatedTab } from "./PaginatedTab.js";
 
-export class MatchesTab extends PaginatedTab<Match> {
+export class MatchesTab extends PaginatedTab<MatchRead> {
   private dashboard: DashboardMatches | null = null;
   private userStats: UserStats;
   private username: string;
@@ -82,14 +82,16 @@ export class MatchesTab extends PaginatedTab<Match> {
     </div>`;
   }
 
-  protected updateTable(matches: Match[]): void {
+  protected updateTable(matches: MatchRead[]): void {
     const table = document.getElementById("match-history-table");
     if (!table) return;
 
     const matchesRows =
       matches.length === 0
         ? [NoMatchesRow()]
-        : matches.map((matchRaw: Match) => MatchRow(matchRaw, this.username));
+        : matches.map((matchRaw: MatchRead) =>
+            MatchRow(matchRaw, this.username)
+          );
 
     table.innerHTML = Table({
       id: "match-history-table",

--- a/app/frontend/src/views/tabs/TournamentsTab.ts
+++ b/app/frontend/src/views/tabs/TournamentsTab.ts
@@ -8,7 +8,7 @@ import { getDataOrThrow } from "../../services/api.js";
 import { getUserDashboardTournamentsByUsername } from "../../services/userStatsServices.js";
 import { DashboardTournaments } from "../../types/DataSeries.js";
 import { PaginatedTab } from "./PaginatedTab.js";
-import { TournamentDTO } from "../../types/ITournament.js";
+import { TournamentRead } from "../../types/ITournament.js";
 import { PaginationControls } from "../../components/PaginationControls.js";
 import {
   NoTournamentsRow,
@@ -17,7 +17,7 @@ import {
 import { Table } from "../../components/Table.js";
 import { getUserTournaments } from "../../services/tournamentService.js";
 
-export class TournamentsTab extends PaginatedTab<TournamentDTO> {
+export class TournamentsTab extends PaginatedTab<TournamentRead> {
   private dashboard: DashboardTournaments | null = null;
   private username: string;
 
@@ -106,14 +106,14 @@ export class TournamentsTab extends PaginatedTab<TournamentDTO> {
     </div>`;
   }
 
-  protected updateTable(tournaments: TournamentDTO[]): void {
+  protected updateTable(tournaments: TournamentRead[]): void {
     const table = document.getElementById("tournament-history-table");
     if (!table) return;
 
     const tournamentsRows =
       tournaments.length === 0
         ? [NoTournamentsRow()]
-        : tournaments.map((tournament: TournamentDTO) =>
+        : tournaments.map((tournament: TournamentRead) =>
             TournamentRow(tournament)
           );
 


### PR DESCRIPTION
### Overview

1. Move bracket creation from Frontend to Backend
2. Hookup playertype in MatchAnnouncement
3. Update Frontend types
4. Modify Match schema / fetching

### 1. Move bracket creation from Frontend to Backend

Instead of creating bracket in Frontend and sending it back and forth as JSON string, we create it in backend. We add new checks via Handlers and Schemas 

#### New model BracketMatch Schema

- Each tournament now has a relationship with BracketMatch. All BracketMatches are the bracket
- BracketMatch has composite id wit tournamentId and MatchNumber
- The fields resemble old Frontend type
- Match has soft relationship with BracketMatch: it saves tournamentId and matchnumber if it was played within tournament. But no relationship since Match entry is only created after BracketMatch has been played

#### Backend 

- service generatBracket is essentially the same as Frontend. New is that it also zips playerNicknames and playerTypes to shuffle them together --> added new helper functions zip, unzip and shuffle
- new services for bracketMatch
- new schema for bracketMatch / adapted Tournament schema (bracket is now array of bracketMatch)
- new transactionTournament: creates tournament, creates bracket
- new transactionUpdateBracket - creates Match, updates current Bracket Match (winner) and tournament (round reached), updates next Bracket Match (nickname, playertype)
- single match creation does not need to be passed TournamentID anymore - tournament match is created with new transactionUpdateBracket
- extracted createMatchAndUpdateStatsTx() from transactionMatch to reuse in transactionUpdateBracket
- adapted createTournamentHandler: validates input, uses new transactionTournament
- new patchTournamentMatchHandler: validates input, uses new transactionUpdateBracket
- new route for patching tournament match: tournaments/:id/matches/:matchNumber
- adapt tournamentSelect to also fetch bracket

#### Frontend

- Tournament class is now reduced to only keep track of bracket matches played in current session. It is inited when created or resumed by fetching all tournament data including bracket. While playing it only updates internal state. 
- endGame only needs to call one service: updateTournamentBracket (if tournament) or createMatch (if single match)

#### Seeding

- adapted Match and Tournament Seed scripts to work with new APIs

### 2. Hookup playertype in MatchAnnouncement

- since we save playertype in BracketMatch we can use the same nicknames input checkboxes to send playertype to backend
- right now a tournament can have two AI players fight each other --> skip option will probably be implemented in another PR

### 3. Update Frontend types

- for Match, Tournament and BracketMatch we now use the generated Prisma types as base types via `import type`
- we then adapt them with Omit or Pick as either create/update type (when the thing is created/updated) or read (for fetching data)
- e.g. we have MatchDB from Prisma, MatchCreate to create and MatchRead to read matches from database
- implemented new types everywhere they are used

### 4. Modify Match schema / fetching

- match schema had tournament object consisting of id and name. Now has tournamentId for creation and tournamentName for fetching
- use flattenMatch to reduce nesting of tournamentName