### PR TITLE
192 password does not reset in settings view

### DIFF
--- a/app/frontend/src/views/SettingsView.ts
+++ b/app/frontend/src/views/SettingsView.ts
@@ -249,29 +249,25 @@ export default class SettingsView extends AbstractView {
       );
       addTogglePasswordListener(this.twoFAPasswordInputEl.id);
       addCloseModalListener(this.twoFAModalEl.id);
-      this.twoFAModalEl.addEventListener("close", () => this.clearQRCode);
-      this.twoFAModalEl.addEventListener("cancel", () => this.clearQRCode);
+      this.twoFAModalEl.addEventListener("close", () => this.clearQRCode());
+      this.twoFAModalEl.addEventListener("cancel", () => this.clearQRCode());
       addCloseModalListener(this.twoFAPasswordModalEl.id);
-      this.twoFAPasswordModalEl.addEventListener(
-        "close",
-        () => this.clearPassword
+      this.twoFAPasswordModalEl.addEventListener("close", () =>
+        this.clearPassword()
       );
-      this.twoFAPasswordModalEl.addEventListener(
-        "cancel",
-        () => this.clearPassword
+      this.twoFAPasswordModalEl.addEventListener("cancel", () =>
+        this.clearPassword()
       );
       if (this.hasTwoFA()) {
         this.twoFAGenerateBackupCodesButtonEl.addEventListener("click", () =>
           this.displayTwoFAPasswordModal("backupCodes")
         );
         addCloseModalListener(this.twoFABackupCodesModalEl.id);
-        this.twoFABackupCodesModalEl.addEventListener(
-          "close",
-          () => this.clearBackupCodesTable
+        this.twoFABackupCodesModalEl.addEventListener("close", () =>
+          this.clearBackupCodesTable()
         );
-        this.twoFABackupCodesModalEl.addEventListener(
-          "cancel",
-          () => this.clearBackupCodesTable
+        this.twoFABackupCodesModalEl.addEventListener("cancel", () =>
+          this.clearBackupCodesTable()
         );
       }
     }

--- a/app/frontend/src/views/SettingsView.ts
+++ b/app/frontend/src/views/SettingsView.ts
@@ -11,7 +11,7 @@ import {
   removeTwoFA,
   verifyTwoFACodeAndGetBackupCodes
 } from "../services/authServices.js";
-import { markInvalid, validateTwoFACode } from "../validate.js";
+import { clearInvalid, markInvalid, validateTwoFACode } from "../validate.js";
 import { ApiError, getDataOrThrow } from "../services/api.js";
 import { router } from "../routing/Router.js";
 import { Link } from "../components/Link.js";
@@ -560,6 +560,7 @@ export default class SettingsView extends AbstractView {
 
   private clearPassword(): void {
     this.twoFAPasswordInputEl.value = "";
+    clearInvalid(this.twoFAPasswordInputEl, this.twoFAPasswordInputErrorEl);
   }
 
   private async displayTwoFAPasswordModal(


### PR DESCRIPTION
For details see #192 

### 1. Password value rest

Add parentheses to call the clear functions correctly

### 2. Error border and span reset

Additionally call ``clearInvalid`` in the ``clearPassword`` function