### PR TITLE
179 online status toast shows wrong name

### DIFF
--- a/app/backend/src/controllers/sse.controllers.js
+++ b/app/backend/src/controllers/sse.controllers.js
@@ -6,6 +6,7 @@ export async function sseConnectionHandler(request, reply) {
   const action = "SSE Connection";
   try {
     const userId = request.user.id;
+    const username = request.user.username;
 
     // Setup SSE headers
     reply.raw.setHeader("Content-Type", "text/event-stream");
@@ -13,7 +14,7 @@ export async function sseConnectionHandler(request, reply) {
     reply.raw.setHeader("Connection", "keep-alive");
     reply.raw.flushHeaders();
 
-    await registerSSEConnection(userId, reply);
+    await registerSSEConnection(userId, username, reply);
   } catch (err) {
     request.log.error(
       { err, body: request.body },

--- a/app/backend/src/services/events/sse.services.js
+++ b/app/backend/src/services/events/sse.services.js
@@ -6,7 +6,7 @@ import {
 } from "./emitter.services.js";
 import { addOnlineUser, removeOnlineUser } from "./presence.services.js";
 
-export async function registerSSEConnection(userId, reply) {
+export async function registerSSEConnection(userId, username, reply) {
   const isFirstConnection = addOnlineUser(userId, reply);
   const emitter = getOrCreateEmitter(userId);
 
@@ -30,22 +30,22 @@ export async function registerSSEConnection(userId, reply) {
     const isOffline = removeOnlineUser(userId, reply);
     if (isOffline) {
       deleteEmitterIfUnused(userId);
-      await notifyFriends(userId, "offline");
+      await notifyFriendStatusChangeEvent(userId, username, "offline");
     }
   });
 
   if (isFirstConnection) {
-    await notifyFriends(userId, "online");
+    await notifyFriendStatusChangeEvent(userId, username, "online");
   }
 }
 
-async function notifyFriends(userId, status) {
+async function notifyFriendStatusChangeEvent(userId, username, status) {
   const friends = await getUserFriends(userId);
 
   for (const friend of friends) {
     emitToUser(friend.friendId, "FriendStatusChangeEvent", {
       requestId: friend.requestId,
-      username: friend.friendUsername,
+      username: username,
       status: status
     });
   }


### PR DESCRIPTION
### Fix

Problem was that we sent the **friend** username. However since the user coming online is sending the event, we should instead send the username (which from perspective of a friend is the friend username)

- retrieve username from JWT and pass it on to service registerSSEConnection(). Then send it via notifyFriends()
- Renamd notifyFriends() to notifyFriendStatusChangeEvent() --> now its more inline with notifyFriendRequestEvent()