### PR TITLE
196 modal closes after submitting wrong value by pressing enter

### DIFF
--- a/app/frontend/src/components/Modal.ts
+++ b/app/frontend/src/components/Modal.ts
@@ -43,7 +43,7 @@ export function addCloseModalListener(id: string) {
   const modalEl = getById<HTMLDialogElement>(id);
   const modalCloseButtonEl = getById<HTMLButtonElement>(`${id}-close-button`);
 
-  modalEl.addEventListener("click", (e) => {
+  modalEl.addEventListener("mousedown", (e) => {
     const dialogDimensions = modalEl.getBoundingClientRect();
     if (
       e.clientX < dialogDimensions.left ||

--- a/app/frontend/src/views/SettingsView.ts
+++ b/app/frontend/src/views/SettingsView.ts
@@ -244,9 +244,9 @@ export default class SettingsView extends AbstractView {
       this.twoFAFormEl.addEventListener("submit", (event) =>
         this.callTwoFAFormAction(event)
       );
-      this.twoFAPasswordFormEl.addEventListener("submit", (event) =>
-        this.callPasswordFormAction(event)
-      );
+      this.twoFAPasswordFormEl.addEventListener("submit", (event) => {
+        this.callPasswordFormAction(event);
+      });
       addTogglePasswordListener(this.twoFAPasswordInputEl.id);
       addCloseModalListener(this.twoFAModalEl.id);
       this.twoFAModalEl.addEventListener("close", () =>
@@ -457,6 +457,7 @@ export default class SettingsView extends AbstractView {
 
       this.twoFAPasswordModalEl.close();
       this.twoFAModalEl.showModal();
+      this.twoFACodeInputEl.focus();
     } catch (error) {
       router.handleError("Error in displayTwoFASetup()", error);
     }
@@ -601,5 +602,6 @@ export default class SettingsView extends AbstractView {
 
     this.twoFAModalEl.close();
     this.twoFAPasswordModalEl.showModal();
+    this.twoFAPasswordInputEl.focus();
   }
 }


### PR DESCRIPTION
For details see #196 

## Reason for bug

The following code snippet, used in the function ``addCloseModalListener``, caused the bug:

```ts
modalEl.addEventListener("click", (e) => {
    const dialogDimensions = modalEl.getBoundingClientRect();
    if (
      e.clientX < dialogDimensions.left ||
      e.clientX > dialogDimensions.right ||
      e.clientY < dialogDimensions.top ||
      e.clientY > dialogDimensions.bottom
    ) {
      modalEl.close();
    }
  });
```

Even though that a listener is added only for the event "click" to the Modal Element, ``modalEl.close()`` got triggered by hitting the key "Enter".

## Fix

Replace the event "click" by the event "mousedown". This event only happens, when you click with the mouse. 

## Additional 

When Two FA Modal or Password Modal get displayed, the Input Element gets focused. 
This makes it easier for the user to provide data without having to manually click on the input field.