### PR TITLE
162 misleading toast

### DIFF
--- a/app/frontend/src/AuthManager.ts
+++ b/app/frontend/src/AuthManager.ts
@@ -54,7 +54,7 @@ export class AuthManager {
       this.authenticated = false;
       this.clearRefreshTimer();
       this.removeActivityListeners();
-      closeSSEConnection();
+      closeSSEConnection(true);
     }
     await this.notify();
   }

--- a/app/frontend/src/routing/Router.ts
+++ b/app/frontend/src/routing/Router.ts
@@ -195,7 +195,7 @@ export class Router {
 
   private handleBeforeUnload = () => {
     console.log(`BeforeUnload triggered`);
-    closeSSEConnection();
+    closeSSEConnection(true);
   };
 
   private async evaluateGuard(guard: RouteGuard): Promise<boolean> {

--- a/app/frontend/src/services/serverSentEventsServices.ts
+++ b/app/frontend/src/services/serverSentEventsServices.ts
@@ -128,7 +128,7 @@ export function openSSEConnection() {
   };
 }
 
-export function closeSSEConnection() {
+export function closeSSEConnection(resetFirstConnection = false) {
   if (eventSource) {
     eventSource.close();
     eventSource = null;
@@ -137,5 +137,9 @@ export function closeSSEConnection() {
   if (reconnectTimeoutID) {
     clearTimeout(reconnectTimeoutID);
     reconnectTimeoutID = null;
+  }
+  if (resetFirstConnection) {
+    isFirstConnection = true;
+    console.log("isFirstConnection has been reset");
   }
 }


### PR DESCRIPTION
### Fix

- add boolean to `closeSSEConnection()` : resetFirstConnection = false
- is set to true on logout and unload (technically not needed for unload)
- after logout and login does not show toast anymore