### PR TITLE
160 loading screen for dashboards

### DIFF
--- a/app/frontend/src/charts/chartUtils.ts
+++ b/app/frontend/src/charts/chartUtils.ts
@@ -48,7 +48,7 @@ export const friendsColors = [
 ];
 
 export function buildBaseOptions(
-  type: "bar" | "donut" | "line",
+  type: "bar" | "donut" | "line" | "radialBar",
   width: number,
   height: number
 ): ApexOptions {

--- a/app/frontend/src/charts/chartUtils.ts
+++ b/app/frontend/src/charts/chartUtils.ts
@@ -46,3 +46,28 @@ export const friendsColors = [
   chartColors.green,
   chartColors.white
 ];
+
+export function buildBaseOptions(
+  type: "bar" | "donut" | "line",
+  width: number,
+  height: number
+): ApexOptions {
+  const options: ApexOptions = {
+    chart: {
+      type: type,
+      fontFamily: "inherit",
+      background: "transparent",
+      toolbar: {
+        show: false
+      },
+      width: width,
+      height: height
+    },
+    noData: {
+      text: "Loading..."
+    },
+    series: []
+  };
+
+  return options;
+}

--- a/app/frontend/src/charts/tournamentsProgressOptions.ts
+++ b/app/frontend/src/charts/tournamentsProgressOptions.ts
@@ -56,7 +56,13 @@ export function buildTournamentsProgressOptions(
     ],
     tooltip: {
       theme: "dark"
-    }
+    },
+    xaxis: {
+      labels: { show: false },
+      axisTicks: { show: false },
+      axisBorder: { show: false }
+    },
+    yaxis: { labels: { show: false } }
   };
   return options;
 }

--- a/app/frontend/src/charts/tournamentsSummaryOptions.ts
+++ b/app/frontend/src/charts/tournamentsSummaryOptions.ts
@@ -3,7 +3,6 @@ import { TournamentSummaryData } from "../types/DataSeries";
 import { tournamentColors } from "./chartUtils.js";
 
 export function buildTournamentsSummaryOptions(
-  name: string,
   data: TournamentSummaryData
 ): ApexOptions {
   const transformedData = data.data.map((point) => ({
@@ -12,6 +11,10 @@ export function buildTournamentsSummaryOptions(
     played: point.played,
     won: point.won
   }));
+  const series = data.data.map((p) => p.winrate);
+  const labels = data.data.map(
+    (p) => `${i18next.t("chart.numPlayers", { num: p.size })}`
+  );
   const options: ApexOptions = {
     chart: {
       type: "radialBar",
@@ -20,15 +23,8 @@ export function buildTournamentsSummaryOptions(
       height: 300,
       width: 400
     },
-    series: [
-      {
-        data: transformedData,
-        parsing: {
-          x: "label",
-          y: "winrate"
-        }
-      }
-    ],
+    labels: labels,
+    series: series,
     plotOptions: {
       radialBar: {
         offsetY: 0,

--- a/app/frontend/src/locales/de.ts
+++ b/app/frontend/src/locales/de.ts
@@ -302,6 +302,7 @@ const de: TranslationShape = {
       passwordUpdateFailed:
         "Passwort konnte nicht aktualisiert werden. Bitte versuche es erneut.",
       passwordUpdatedSuccess: "Passwort erfolgreich aktualisiert!",
+      tabError: "Der Tab konnte nicht initialisiert werden.",
       twoFASetupSuccess: "2FA erfolgreich aktiviert!",
       twoFARemoveSuccess: "2FA erfolgreich deaktiviert!",
       profileUpdateFailed:

--- a/app/frontend/src/locales/en.ts
+++ b/app/frontend/src/locales/en.ts
@@ -298,6 +298,7 @@ const en = {
       profileUpdatedSuccess: "Profile updated successfully!",
       registrationSuccess: "Successfully registered {{username}}!",
       sendSuccess: "Friend request sent to {{username}}",
+      tabError: "The tab failed to initialize.",
       terminatedFriendship: "Friendship terminated with ",
       tokenRefreshFailed: "Token refresh failed. Please try again.",
       userAcceptedFriendRequest:

--- a/app/frontend/src/locales/fr.ts
+++ b/app/frontend/src/locales/fr.ts
@@ -287,6 +287,7 @@ const fr: TranslationShape = {
       passwordUpdatedSuccess: "Mot de passe mis à jour avec succès !",
       profileUpdateFailed:
         "Échec de la mise à jour du profil. Veuillez réessayer.",
+      tabError: "L'onglet n'a pas pu s'initialiser.",
       twoFASetupSuccess:
         "Configuration de l’authentification à deux facteurs réussie !",
       twoFARemoveSuccess:

--- a/app/frontend/src/locales/pi.ts
+++ b/app/frontend/src/locales/pi.ts
@@ -296,6 +296,7 @@ const pi: TranslationShape = {
       passwordUpdateFailed:
         "Couldn’t set yer new passphrase. Try again or be cursed!",
       passwordUpdatedSuccess: "Secret code changed! Keep it close!",
+      tabError: "Arrr! This here tab be refusin' to set sail!",
       twoFASetupSuccess: "Secret digits be rigged ‘n ready!",
       twoFARemoveSuccess: "Secret digits be scuttled! Ye be sailin’ free!",
       profileUpdateFailed: "Profile be cursed – try again later!",

--- a/app/frontend/src/locales/tr.ts
+++ b/app/frontend/src/locales/tr.ts
@@ -292,6 +292,7 @@ const tr: TranslationShape = {
       logoutError: "Logout failed. Reattempt required.",
       passwordUpdateFailed: "Access code update failed. Retry advised.",
       passwordUpdatedSuccess: "Access code updated successfully!",
+      tabError: "Tab failed to initialize within the Grid.",
       twoFASetupSuccess: "Cipher activated successfully!",
       twoFARemoveSuccess: "Cipher deactivated successfully!",
       profileUpdateFailed: "Profile update failed. Retry advised.",

--- a/app/frontend/src/views/StatsView.ts
+++ b/app/frontend/src/views/StatsView.ts
@@ -167,7 +167,7 @@ export default class StatsView extends AbstractView {
       this.tabs[tabId].onShow();
     } catch (error) {
       console.error(`Error while showing tab ${this.currentTabId}`, error);
-      toaster.error("Something went wrong");
+      toaster.error(i18next.t("toast.tabError"));
     }
   }
 

--- a/app/frontend/src/views/StatsView.ts
+++ b/app/frontend/src/views/StatsView.ts
@@ -164,7 +164,7 @@ export default class StatsView extends AbstractView {
       const container = getById<HTMLDivElement>(this.currentTabId);
       container.classList.toggle("hidden");
 
-      this.tabs[tabId].onShow();
+      await this.tabs[tabId].onShow();
     } catch (error) {
       console.error(`Error while showing tab ${this.currentTabId}`, error);
       toaster.error(i18next.t("toast.tabError"));

--- a/app/frontend/src/views/StatsView.ts
+++ b/app/frontend/src/views/StatsView.ts
@@ -164,7 +164,7 @@ export default class StatsView extends AbstractView {
       const container = getById<HTMLDivElement>(this.currentTabId);
       container.classList.toggle("hidden");
 
-      await this.tabs[tabId].onShow();
+      this.tabs[tabId].onShow();
     } catch (error) {
       console.error(`Error while showing tab ${this.currentTabId}`, error);
       toaster.error("Something went wrong");
@@ -212,7 +212,7 @@ export default class StatsView extends AbstractView {
     buttons.forEach((button) => {
       button.addEventListener("click", async () => {
         const tabId = button.dataset.tab!;
-        await this.showTab(tabId);
+        this.showTab(tabId);
 
         buttons.forEach((btn) => {
           btn.classList.remove("active-link");

--- a/app/frontend/src/views/StatsView.ts
+++ b/app/frontend/src/views/StatsView.ts
@@ -22,6 +22,7 @@ import { TabButton } from "../components/TabButton.js";
 import { MatchesTab } from "./tabs/MatchesTab.js";
 import { TournamentsTab } from "./tabs/TournamentsTab.js";
 import { FriendsTab } from "./tabs/FriendsTab.js";
+import { toaster } from "../Toaster.js";
 
 export default class StatsView extends AbstractView {
   private viewType: "self" | "friend" | "public" = "public";
@@ -152,17 +153,22 @@ export default class StatsView extends AbstractView {
   }
 
   async showTab(tabId: string) {
-    if (this.currentTabId) {
-      this.tabs[this.currentTabId].onHide();
+    try {
+      if (this.currentTabId) {
+        this.tabs[this.currentTabId].onHide();
+        const container = getById<HTMLDivElement>(this.currentTabId);
+        container.classList.toggle("hidden");
+      }
+
+      this.currentTabId = tabId;
       const container = getById<HTMLDivElement>(this.currentTabId);
       container.classList.toggle("hidden");
+
+      await this.tabs[tabId].onShow();
+    } catch (error) {
+      console.error(`Error while showing tab ${this.currentTabId}`, error);
+      toaster.error("Something went wrong");
     }
-
-    this.currentTabId = tabId;
-    const container = getById<HTMLDivElement>(this.currentTabId);
-    container.classList.toggle("hidden");
-
-    await this.tabs[tabId].onShow();
   }
 
   getTabsHTML(): string {

--- a/app/frontend/src/views/StatsView.ts
+++ b/app/frontend/src/views/StatsView.ts
@@ -180,11 +180,10 @@ export default class StatsView extends AbstractView {
     }
 
     let allTabsHTML = "";
-    for (const tabKey in this.tabs) {
-      if (Object.prototype.hasOwnProperty.call(this.tabs, tabKey)) {
-        allTabsHTML += this.tabs[tabKey].getHTML();
-      }
+    for (const tabId in this.tabs) {
+      allTabsHTML += this.tabs[tabId].getHTML();
     }
+
     return /* HTML */ `
       <div class="flex space-x-4 border-b border-grey mb-4">
         ${TabButton({
@@ -222,5 +221,15 @@ export default class StatsView extends AbstractView {
         button.classList.add("active-link");
       });
     });
+  }
+
+  unmount(): void {
+    console.log("Cleaning up StatsView");
+    for (const tabId in this.tabs) {
+      const tab = this.tabs[tabId];
+      if (tab) {
+        tab.destroyCharts();
+      }
+    }
   }
 }

--- a/app/frontend/src/views/StatsView.ts
+++ b/app/frontend/src/views/StatsView.ts
@@ -212,7 +212,7 @@ export default class StatsView extends AbstractView {
     buttons.forEach((button) => {
       button.addEventListener("click", async () => {
         const tabId = button.dataset.tab!;
-        this.showTab(tabId);
+        await this.showTab(tabId);
 
         buttons.forEach((btn) => {
           btn.classList.remove("active-link");

--- a/app/frontend/src/views/tabs/AbstractTab.ts
+++ b/app/frontend/src/views/tabs/AbstractTab.ts
@@ -52,4 +52,19 @@ export abstract class AbstractTab {
       }
     }
   }
+
+  public destroyCharts(): void {
+    for (const chartId in this.charts) {
+      const chart = this.charts[chartId];
+      if (chart) {
+        try {
+          chart.destroy();
+        } catch (error) {
+          console.error(`Chart ${chartId} failed to destroy`, error);
+          toaster.error(i18next.t("toast.chartError"));
+        }
+      }
+    }
+    this.charts = {};
+  }
 }

--- a/app/frontend/src/views/tabs/FriendsTab.ts
+++ b/app/frontend/src/views/tabs/FriendsTab.ts
@@ -71,18 +71,19 @@ export class FriendsTab extends AbstractTab {
 
   override async onShow(): Promise<void> {
     await super.onShow();
-    this.renderFriendSelector(this.dashboard!.matchStats);
   }
 
   async initData(): Promise<void> {
     this.dashboard = getDataOrThrow(await getUserDashboardFriends());
     this.populateChartOptions();
+    this.renderFriendSelector(this.dashboard!.matchStats);
   }
 
   override onHide(): void {
     super.onHide();
 
     this.friendManager.deselectAllFriendsExcept(this.username);
+    this.resetFriendSelectorButtons();
   }
 
   private populateChartOptions(): void {
@@ -173,5 +174,30 @@ export class FriendsTab extends AbstractTab {
     this.charts["friends-winrate"].updateSeries(filtered.winRate);
     this.charts["friends-match-stats"].updateSeries(filtered.matchStats);
     this.charts["friends-winstreak"].updateSeries(filtered.winStreak);
+  }
+
+  private resetFriendSelectorButtons() {
+    const container = getById<HTMLDivElement>("friend-selector");
+    if (!container) return;
+
+    const buttons = getAllBySelector<HTMLButtonElement>("button", {
+      root: container,
+      strict: false
+    });
+
+    buttons.forEach((btn) => {
+      const friendName = btn.innerText;
+      const isSelected = this.friendManager
+        .getSelectedFriends()
+        .includes(friendName);
+
+      if (isSelected) {
+        btn.className = this.friendManager.getBtnClassesSelected(friendName);
+        btn.dataset.selected = "true";
+      } else {
+        btn.className = this.friendManager.getBtnClassesNotSelected();
+        btn.dataset.selected = "false";
+      }
+    });
   }
 }

--- a/app/frontend/src/views/tabs/FriendsTab.ts
+++ b/app/frontend/src/views/tabs/FriendsTab.ts
@@ -24,7 +24,7 @@ export class FriendsTab extends AbstractTab {
   }
 
   getHTML(): string {
-    return /* HTML */ ` <div id="tab-friends">
+    return /* HTML */ ` <div id="tab-friends" class="hidden">
       <div class="w-full max-w-screen-2xl mx-auto px-4 py-8 space-y-8">
         ${Header1({
           text: i18next.t("statsView.dashboard"),

--- a/app/frontend/src/views/tabs/FriendsTab.ts
+++ b/app/frontend/src/views/tabs/FriendsTab.ts
@@ -1,3 +1,4 @@
+import { buildBaseOptions } from "../../charts/chartUtils.js";
 import { FriendManager } from "../../charts/FriendManager.js";
 import { buildFriendsMatchStatsOptions } from "../../charts/friendsMatchStatsOptions.js";
 import { buildFriendsWinRateOptions } from "../../charts/friendsWinRateOptions.js";
@@ -21,6 +22,11 @@ export class FriendsTab extends AbstractTab {
     this.username = username;
     this.friendManager = new FriendManager();
     this.friendManager.selectFriend(this.username);
+    this.chartBaseOptions = {
+      "friends-match-stats": buildBaseOptions("bar", 750, 300),
+      "friends-winrate": buildBaseOptions("bar", 600, 300),
+      "friends-winstreak": buildBaseOptions("bar", 600, 300)
+    };
   }
 
   getHTML(): string {
@@ -68,10 +74,9 @@ export class FriendsTab extends AbstractTab {
     this.renderFriendSelector(this.dashboard!.matchStats);
   }
 
-  async init(): Promise<void> {
+  async initData(): Promise<void> {
     this.dashboard = getDataOrThrow(await getUserDashboardFriends());
     this.populateChartOptions();
-    this.isInit = true;
   }
 
   override onHide(): void {

--- a/app/frontend/src/views/tabs/MatchesTab.ts
+++ b/app/frontend/src/views/tabs/MatchesTab.ts
@@ -28,7 +28,7 @@ export class MatchesTab extends PaginatedTab<MatchRead> {
   }
 
   getHTML(): string {
-    return /* HTML */ ` <div id="tab-matches" class="tab-content">
+    return /* HTML */ ` <div id="tab-matches" class="hidden">
       <div class="w-full max-w-screen-2xl mx-auto px-4 py-4">
         ${Header1({
           text: i18next.t("statsView.dashboard"),

--- a/app/frontend/src/views/tabs/MatchesTab.ts
+++ b/app/frontend/src/views/tabs/MatchesTab.ts
@@ -1,3 +1,4 @@
+import { buildBaseOptions } from "../../charts/chartUtils.js";
 import { buildMatchesScoreDiffOptions } from "../../charts/matchesScoreDiffOptions.js";
 import { buildMatchesScoresLastTenDaysOptions } from "../../charts/matchesScoresLastTenDaysOptions.js";
 import { buildMatchesWinLossOptions } from "../../charts/matchesWinLossOptions.js";
@@ -25,6 +26,12 @@ export class MatchesTab extends PaginatedTab<MatchRead> {
     super(10, "matches-prev-btn", "matches-next-btn", "matches-page-indicator");
     this.userStats = userStats;
     this.username = username;
+    this.chartBaseOptions = {
+      "win-loss-chart": buildBaseOptions("donut", 450, 300),
+      "win-rate-chart": buildBaseOptions("line", 750, 300),
+      "score-diff-chart": buildBaseOptions("bar", 600, 300),
+      "scores-last-ten-chart": buildBaseOptions("bar", 600, 300)
+    };
   }
 
   getHTML(): string {
@@ -114,12 +121,11 @@ export class MatchesTab extends PaginatedTab<MatchRead> {
     );
   }
 
-  async init(): Promise<void> {
+  async initData(): Promise<void> {
     this.dashboard = getDataOrThrow(
       await getUserDashboardMatchesByUsername(this.username)
     );
     this.populateMatchesCharts();
-    this.isInit = true;
   }
 
   private populateMatchesCharts(): void {

--- a/app/frontend/src/views/tabs/TournamentsTab.ts
+++ b/app/frontend/src/views/tabs/TournamentsTab.ts
@@ -17,6 +17,7 @@ import {
 import { Table } from "../../components/Table.js";
 import { getUserTournaments } from "../../services/tournamentService.js";
 import { getById } from "../../utility.js";
+import { buildBaseOptions } from "../../charts/chartUtils.js";
 
 export class TournamentsTab extends PaginatedTab<TournamentRead> {
   private dashboard: DashboardTournaments | null = null;
@@ -30,6 +31,22 @@ export class TournamentsTab extends PaginatedTab<TournamentRead> {
       "tournaments-page-indicator"
     );
     this.username = username;
+    this.chartBaseOptions = {
+      "tournament-summary": buildTournamentsSummaryOptions({
+        data: [
+          { size: 4, winrate: 0, played: 0, won: 0 },
+          { size: 8, winrate: 0, played: 0, won: 0 },
+          { size: 16, winrate: 0, played: 0, won: 0 }
+        ]
+      }),
+      "tournament-played": buildBaseOptions("bar", 800, 300),
+      "tournament-last-10-days-4": buildBaseOptions("bar", 800, 300),
+      "tournament-progress-4": buildBaseOptions("bar", 400, 350),
+      "tournament-last-10-days-8": buildBaseOptions("bar", 800, 300),
+      "tournament-progress-8": buildBaseOptions("bar", 400, 350),
+      "tournament-last-10-days-16": buildBaseOptions("bar", 800, 300),
+      "tournament-progress-16": buildBaseOptions("bar", 400, 350)
+    };
   }
 
   getHTML(): string {
@@ -135,12 +152,11 @@ export class TournamentsTab extends PaginatedTab<TournamentRead> {
     );
   }
 
-  async init(): Promise<void> {
+  async initData(): Promise<void> {
     this.dashboard = getDataOrThrow(
       await getUserDashboardTournamentsByUsername(this.username)
     );
     this.populateChartOptions();
-    this.isInit = true;
   }
 
   private populateChartOptions(): void {
@@ -148,7 +164,6 @@ export class TournamentsTab extends PaginatedTab<TournamentRead> {
 
     this.chartOptions = {
       "tournament-summary": buildTournamentsSummaryOptions(
-        i18next.t("chart.summary"),
         this.dashboard.summary
       ),
       "tournament-played": buildTournamentsPlayedOptions(

--- a/app/frontend/src/views/tabs/TournamentsTab.ts
+++ b/app/frontend/src/views/tabs/TournamentsTab.ts
@@ -33,7 +33,7 @@ export class TournamentsTab extends PaginatedTab<TournamentRead> {
   }
 
   getHTML(): string {
-    return /* HTML */ ` <div id="tab-tournaments">
+    return /* HTML */ ` <div id="tab-tournaments" class="hidden">
       <div class="w-full max-w-screen-2xl mx-auto px-4 py-4">
         ${Header1({
           text: i18next.t("statsView.dashboard"),


### PR DESCRIPTION
### Overview

Changes to make rendering of charts (especially TournamentsTab) a bit more smooth: 
1. render all tabs HTML once and use class hidden to show / hide active / non-active tab
2. render charts with baseOptions, fetch data and then update options with full options
3. render charts only once, destroy them on unmount
4. adapt FriendsTab selector

There is still a noticeable delay but I think its better than before 

### 1. render HTML once

- before we would always re-render tab HTML in a div of StatsView
- now we init all tabs with initTabs() before updating HTML. We loop through tabs to get their HTML which has class="hidden". Then everything is added to DOM
- tabShow() toggles class hidden

### 2. render charts with base options

- split init() function of AbstractTab into initCharts() and initData()
- we render charts with initCharts() with minimal options (type, width, height) 
- for base options we use new function buildBaseOptions(). The baseOptions are saved in its own array and filled in constructor
- then we fetch data with initData()

### 3. render charts only once, destroy them on unmount

- instead of creating and destroying we create charts only once with init
- onShow() which runs after init() updates charts with full options
- onHide updates series with empty series so it will animate again
- buildTournamentsSummaryOptions() did not work with this style - error that it expects different data(?). Could not find solution, we just use the real options builder and pass in empty object
- buildTournamentsProgressOptions added data x/yaxis labels --> explicitly turned them off
- all charts are destroyed on StatsView.unmount

### 4. adapt FriendsTab selector

- friend selector was always rendered new in showTab(), since previous HTML got replaced
- now we keep HTML, so we only do it once in initData()
- in onHide() we need to reset the button color which is done with new resetFriendSelectorButtons()