### PR TITLE
222 update dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,1 @@
-FROM mcr.microsoft.com/devcontainers/base:noble
-
-RUN apt-get update \
-  && apt-get -y install --no-install-recommends \
-  curl \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://deb.nodesource.com/setup_23.x -o nodesource_setup.sh \
-  && bash nodesource_setup.sh \
-  && apt-get install -y nodejs \
-  && rm nodesource_setup.sh
-
-RUN npm install -g npm@11.3.0
+FROM node:24-bookworm

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,22 +1,23 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
 {
   "name": "Transcendence",
   "build": {
     "dockerfile": "Dockerfile"
   },
-  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 
   // Features to add to the dev container. More info: https://containers.dev/features.
-  // "features": {},
+  "features": {
+    "ghcr.io/nils-geistmann/devcontainers-features/zsh:0": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
 
-  // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // "forwardPorts": [],
+  "forwardPorts": [
+    8080, // HTTP endpoint of WAF
+    8443, // HTTPS endpoint of WAF
+    4000 // default port of application
+  ],
 
-  // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "npm ci",
+  "postCreateCommand": "npm ci", // clean install of npm packages
 
-  // Configure tool-specific properties.
   "customizations": {
     "vscode": {
       "extensions": [
@@ -42,6 +43,6 @@
     }
   }
 
-  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-  // "remoteUser": "root"
+  // Uncomment to connect as node instead. Useful in rootful docker environments to align permissions with current user
+  //"remoteUser": "node"
 }

--- a/app/backend/src/config/env.js
+++ b/app/backend/src/config/env.js
@@ -123,10 +123,11 @@ const schema = {
   }
 };
 
+const projectRoot = path.resolve(__dirname, "../../../..");
 const config = envSchema({
   schema: schema,
   dotenv: {
-    path: path.join(__dirname, "../../.env")
+    path: path.join(projectRoot, ".env")
   }
 });
 


### PR DESCRIPTION
### Switch base image

- from mcr.microsoft.com/devcontainers/base:noble to node:24-bookworm 
- is currently also latest tag
- used image with fixed version to avoid breaking changes
- decided against slim since dev container is not used for shipping
- since node image already has node and npm installed removed lines from Dockerfile

### Update devcontainers.json

Other image had some nice things set which added via dev containers file, also added new features
- feature zsh: switch from bash to zsh with fancier command line format
- feature docker-in-docker: run docker compose inside dev container. This means everything can be done inside dev container, no switch needed 
- forwardPorts: automatic forwarding was a bit janky with new image. Explicitly set 400 for direct dev and 8080 / 8443 for project dev 
- remoteUser: set to node and commented out. In container we are by default "root". If run from school /rootless docker this maps back to user id. If dev container is used with rootful docker one has to switch to user node which has user mappings --> switch causes problem in school setup

### Update env path

- .env in config.js is searched at project root. This means we can use same env file when running via npm run dev or via make up 